### PR TITLE
[FEAT] Management Scraper State

### DIFF
--- a/scrapper-server/src/common/Queue.ts
+++ b/scrapper-server/src/common/Queue.ts
@@ -8,6 +8,12 @@ export default class Queue<T> {
   tail: QueueNode<T> | null = null;
   length = 0;
 
+  reset() {
+    this.length = 0;
+    this.head = null;
+    this.tail = null;
+  }
+
   front() {
     if (this.isEmpty() || this.head === null) {
       return null;

--- a/scrapper-server/src/index.ts
+++ b/scrapper-server/src/index.ts
@@ -9,10 +9,10 @@ dotenv.config();
 // mongoDB();
 
 async function main() {
-  NoticeScraper.run();
-  CalendarScraper.run();
-  DomitoryScraper.run();
-  CafeteriaScraper.run();
+  NoticeScraper.start();
+  CalendarScraper.start();
+  DomitoryScraper.start();
+  CafeteriaScraper.start();
 }
 
 main();

--- a/scrapper-server/src/scrapers/Scraper.ts
+++ b/scrapper-server/src/scrapers/Scraper.ts
@@ -9,9 +9,19 @@ const WINDOW_SIZE = {
   HEIGHT: 1080,
 };
 
+export const SCRAPER_STATE = {
+  WAIT: "WAIT",
+  RUNNING: "RUNNING",
+  STOPPED: "STOPPED",
+  ERROR: "ERROR",
+} as const;
+
+type SCRAPER_STATE = typeof SCRAPER_STATE[keyof typeof SCRAPER_STATE];
+
 const SCENARIO_DELAY = 1000;
 
 abstract class Scraper<T> {
+  state: SCRAPER_STATE = SCRAPER_STATE.STOPPED;
   scraper: Page | null = null;
   queue: Queue<Scenario<T>>;
   loadedScript: boolean = false;


### PR DESCRIPTION
## 👀 이슈

resolve #14 

## 📌 개요

스크래퍼의 상태관리

## 👩‍💻 작업 사항

스크래퍼의 큐가 비어있다면 스크래퍼를 중지
스크래퍼를 초기화하고 재시작할 수 있도록 기능구현

