### PR TITLE
[FIX] Change calender naming

### DIFF
--- a/scrapper-server/src/interfaces/CalendarScript.ts
+++ b/scrapper-server/src/interfaces/CalendarScript.ts
@@ -1,6 +1,6 @@
 export interface CalendarScript {
   url: string;
-  scripts: { year: number; key: string }[];
+  years: { year: number; key: string }[];
   waitCalendarSelector: string;
   getSchedules: Function;
 }

--- a/scrapper-server/src/scrapers/CalendarScraper/index.ts
+++ b/scrapper-server/src/scrapers/CalendarScraper/index.ts
@@ -21,16 +21,14 @@ class CalendarScraper extends Scraper<CalendarScript> {
 
     const refinedData = [];
 
-    for (let i = 0; i < calendarScript.scripts.length; i++) {
-      await this.scraper.goto(
-        calendarScript.url + calendarScript.scripts[i].key,
-      );
+    for (let i = 0; i < calendarScript.years.length; i++) {
+      await this.scraper.goto(calendarScript.url + calendarScript.years[i].key);
       await this.scraper.waitForSelector(calendarScript.waitCalendarSelector);
       await this.evaluateScript(calendarScript);
       const mockData = await this.scraper.evaluate("script.getSchedules()");
       for (let j = 0; j < mockData.length; j++) {
         refinedData.push({
-          ...ArrayToDate(calendarScript.scripts[i].year, mockData[j][0]),
+          ...ArrayToDate(calendarScript.years[i].year, mockData[j][0]),
           content: mockData[j][1],
         });
       }

--- a/scrapper-server/src/scrapers/CalendarScraper/scripts/year.js
+++ b/scrapper-server/src/scrapers/CalendarScraper/scripts/year.js
@@ -1,6 +1,6 @@
 const script = {
   url: "https://www.chungbuk.ac.kr/site/www/sub.do?key=",
-  scripts: [
+  years: [
     {
       year: 2020,
       key: "1728",
@@ -15,7 +15,7 @@ const script = {
   getSchedules: function () {
     const data = [];
     const content = document.querySelectorAll(
-      `#contents > div.academic_calendar > ul > li > div:nth-child(2) > div:nth-child(1) > ul > li`
+      `#contents > div.academic_calendar > ul > li > div:nth-child(2) > div:nth-child(1) > ul > li`,
     );
     for (let i = 0; i < content.length; i++) {
       let date = content[i].querySelector("span").textContent;


### PR DESCRIPTION
## 👀 이슈
resolve #1 

## 📌 개요
학사일정 스크래퍼 스크립트의 네이밍을 바꿉니다.

## 👩‍💻 작업 사항
`scripts`에서 `years`로 바꿉니다.

## ✅ 참고 사항
```
years: [
    {
      year: 2020,
      key: "1728",
    },
    {
      year: 2021,
      key: "1804",
    },
  ]
```