### PR TITLE
[admin] 관리자 페이지 코드리뷰 반영 UI 리펙토링

### DIFF
--- a/packages/admin/src/__mocks__/noticeScenarios.ts
+++ b/packages/admin/src/__mocks__/noticeScenarios.ts
@@ -1,15 +1,24 @@
 const scenarios = [
   {
     id: 1,
-    titleText: "소프트웨어학과",
+    title: "소프트웨어학과",
     subTitle: "공지사항",
-    tags: ["전자정보대학", "관리 요망", "테스트 태그", "많은", "태그가", "있을 때", "이렇게", "보입니다"],
+    tags: [
+      "전자정보대학",
+      "관리 요망",
+      "테스트 태그",
+      "많은",
+      "태그가",
+      "있을 때",
+      "이렇게",
+      "보입니다",
+    ],
     group: "전자정보대학",
     status: "실행중",
   },
   {
     id: 2,
-    titleText: "컴퓨터공학과",
+    title: "컴퓨터공학과",
     subTitle: "공지사항",
     tags: ["전자정보대학"],
     group: "전자정보대학",
@@ -17,7 +26,7 @@ const scenarios = [
   },
   {
     id: 3,
-    titleText: "정보통신학과",
+    title: "정보통신학과",
     subTitle: "공지사항",
     tags: ["전자정보대학"],
     group: "전자정보대학",
@@ -25,7 +34,7 @@ const scenarios = [
   },
   {
     id: 4,
-    titleText: "전자공학부",
+    title: "전자공학부",
     subTitle: "공지사항",
     tags: ["전자정보대학"],
     group: "전자정보대학",
@@ -33,7 +42,7 @@ const scenarios = [
   },
   {
     id: 5,
-    titleText: "전기공학부",
+    title: "전기공학부",
     subTitle: "공지사항",
     tags: ["전자정보대학"],
     group: "전자정보대학",
@@ -41,7 +50,7 @@ const scenarios = [
   },
   {
     id: 6,
-    titleText: "지능로봇공학과",
+    title: "지능로봇공학과",
     subTitle: "공지사항",
     tags: ["전자정보대학"],
     group: "전자정보대학",
@@ -49,7 +58,7 @@ const scenarios = [
   },
   {
     id: 7,
-    titleText: "심리학과",
+    title: "심리학과",
     subTitle: "공지사항",
     tags: ["사회과학대학"],
     group: "사회과학대학",
@@ -57,7 +66,7 @@ const scenarios = [
   },
   {
     id: 8,
-    titleText: "사회학과",
+    title: "사회학과",
     subTitle: "공지사항",
     tags: ["사회과학대학"],
     group: "사회과학대학",
@@ -65,7 +74,7 @@ const scenarios = [
   },
   {
     id: 9,
-    titleText: "정치외교학과",
+    title: "정치외교학과",
     subTitle: "공지사항",
     tags: ["사회과학대학"],
     group: "사회과학대학",
@@ -73,7 +82,7 @@ const scenarios = [
   },
   {
     id: 10,
-    titleText: "철학과",
+    title: "철학과",
     subTitle: "공지사항",
     tags: ["인문대학"],
     group: "인문대학",

--- a/packages/admin/src/components/Navigation/index.jsx
+++ b/packages/admin/src/components/Navigation/index.jsx
@@ -1,23 +1,30 @@
 import { useContext } from "react";
-import { menuContext, sidebarMenus } from "@admin/utils/menuContext";
+import { MenuContext, MenuConfig } from "@admin/utils/menuContext";
 import { cx } from "@emotion/css";
 import getStyle from "./style";
 
 export default function Natigation() {
-  const { status, setContext } = useContext(menuContext);
-  const { Navigation, activated, sideNavUl, sideNavLi, logo, insideBtn } =
-    getStyle();
+  const { status, setContext } = useContext(MenuContext);
+  const style = getStyle();
+  const sidebarMenus = [
+    MenuConfig.all,
+    MenuConfig.running,
+    MenuConfig.waiting,
+    MenuConfig.error,
+  ];
 
   return (
-    <nav className={Navigation}>
-      <ul className={sideNavUl}>
-        <li className={logo}>CMI</li>
+    <nav className={style.Navigation}>
+      <ul className={style.sideNavUl}>
+        <li className={style.logo}>CMI</li>
         {sidebarMenus.map((item) => (
-          <li key={item} className={sideNavLi}>
+          <li key={item} className={style.sideNavLi}>
             <button
               type="button"
               onClick={() => setContext(item)}
-              className={cx(insideBtn, item === status ? activated : "")}
+              className={cx(style.insideBtn, {
+                [style.activated]: item === status,
+              })}
             >
               {item}
             </button>

--- a/packages/admin/src/components/Navigation/style.ts
+++ b/packages/admin/src/components/Navigation/style.ts
@@ -10,50 +10,48 @@ export default () => {
   const logo = cssHash();
 
   const Navigation = css`
-    background-color: ${colors.$white};
     position: fixed;
     top: 0;
     left: 0;
-    width: 200px;
+    width: 13rem;
     height: 100vh;
+    z-index: 1;
+    background-color: ${colors.$white};
 
     .${sideNavUl} {
-        margin: 20px 0 0 20px;
-        display: flex;
-        flex-direction: column;
-        align-items: left;
-        width: 100%
-        height: 100%
+      display: flex;
+      flex-direction: column;
+      margin: 2rem 0 0 2rem;
+      align-items: left;
     }
 
     .${sideNavLi} {
-        margin: 20px 0 0 0;
-        font-size: 1.3rem;
+      margin-top: 1.5rem;
+      font-size: 1.3rem;
     }
 
     .${logo} {
-        font-weight: bold;
-        font-size: 1.3rem;
+      font-size: 1.3rem;
+      font-weight: bold;
     }
 
     .${insideBtn} {
-        cursor: pointer;
-        border: none;
-        background-color: transparent;
-        font-size: 1.2rem;
-        font-weight: 200;
+      font-size: 1.2rem;
+      font-weight: 200;
+      cursor: pointer;
+      border: none;
+      background-color: transparent;
     }
 
     .${insideBtn}:hover {
-        font-weight: 600;
-        color: ${colors.$darkNavy};
+      font-weight: 600;
+      color: ${colors.$darkNavy};
     }
 
     .${activated} {
-        font-weight: 600;
-        color: ${colors.$darkNavy};
+      font-weight: 600;
+      color: ${colors.$darkNavy};
     }
-
   `;
 
   return { Navigation, activated, sideNavUl, sideNavLi, logo, insideBtn };

--- a/packages/admin/src/components/Scenario/Card/index.tsx
+++ b/packages/admin/src/components/Scenario/Card/index.tsx
@@ -1,53 +1,37 @@
-import { Element, scenarioConfig } from "@shared/types";
-import { sidebarMenus } from "@admin/utils/menuContext";
+import { Element, ScenarioConfig } from "@shared/types";
+import { MenuConfig } from "@admin/utils/menuContext";
 import { cx } from "@emotion/css";
 import getStyle from "./style";
 
-interface ScenarioCardConfig {
-  scenario: scenarioConfig;
-}
+type Props = {
+  scenario: ScenarioConfig;
+};
 
-export default function ScenarioCard({
-  className,
-  scenario,
-}: ScenarioCardConfig & Element) {
-  const { titleText, subTitle, status, tags } = scenario;
-  const {
-    scenarioCard,
-    title,
-    tag,
-    statusText,
-    statusContainer,
-    red,
-    yellow,
-    green,
-  } = getStyle();
-
+export default function ScenarioCard({ className, scenario }: Props & Element) {
+  const { title, subTitle, status, tags } = scenario;
+  const style = getStyle();
   let statusColor = "";
 
-  // TODO: ESLint 규칙에 추가하기
-  // eslint-disable-next-line default-case
   switch (status) {
-    case sidebarMenus[1]:
-      statusColor = green;
+    case MenuConfig.running:
+      statusColor = style.green;
       break;
-    case sidebarMenus[2]:
-      statusColor = yellow;
+    case MenuConfig.waiting:
+      statusColor = style.yellow;
       break;
-    case sidebarMenus[3]:
-      statusColor = red;
-      break;
+    default:
+      statusColor = style.red;
   }
 
   return (
-    <div className={cx(scenarioCard, className)}>
-      <h2 className={title}>{titleText}</h2>
+    <div className={cx(style.scenarioCard, className)}>
+      <h2 className={style.title}>{title}</h2>
       <h3>{subTitle}</h3>
       {tags.map((tagText) => (
-        <span className={tag} key={tagText}>{`# ${tagText}`}</span>
+        <span className={style.tag} key={tagText}>{`# ${tagText}`}</span>
       ))}
-      <div className={statusContainer}>
-        <span className={statusText}>{status}</span>
+      <div className={style.statusContainer}>
+        <span className={style.statusText}>{status}</span>
         <div className={statusColor}></div>
       </div>
     </div>

--- a/packages/admin/src/components/Scenario/Card/style.ts
+++ b/packages/admin/src/components/Scenario/Card/style.ts
@@ -12,74 +12,83 @@ export default () => {
   const green = cssHash();
 
   const scenarioCard = css`
-    position: relative;
-    padding: 20px;
-    box-shadow: rgba(17, 17, 26, 0.05) 0px 1px 0px, rgba(17, 17, 26, 0.1) 0px 0px 8px;
-    border-radius: 12px;
-    width: 300px;
-    min-height: 230px;
-    background-color: ${colors.$white};
     display: flex;
+    position: relative;
     flex-direction: column;
     align-items: flex-start;
     flex: none;
+    width: 19rem;
+    min-height: 15rem;
+    padding: 1.5rem;
+    box-shadow: rgba(17, 17, 26, 0.05) 0px 1px 0px,
+      rgba(17, 17, 26, 0.1) 0px 0px 8px;
+    border-radius: 1rem;
+    background-color: ${colors.$white};
 
     :hover {
-      outline: 2px solid ${colors.$lightBlue};
+      outline: 0.2rem solid ${colors.$lightBlue};
       cursor: pointer;
     }
-    
+
     .${title} {
+      margin-bottom: 0.7rem;
       font-size: 1.4rem;
-      color: ${colors.$darkNavy};
       font-weight: bold;
-      margin-bottom: 5px;
+      color: ${colors.$darkNavy};
     }
 
     .${tag} {
+      margin-top: 0.5rem;
+      padding: 0.4rem 0.6rem;
+      font-size: 0.9rem;
+      border-radius: 0.5rem;
       background-color: ${colors.$lightBlue};
       color: ${colors.$white};
-      margin-top: 10px;
-      padding: 7px 10px;
-      font-size: 0.9rem;
-      border-radius: 10px;
     }
 
     .${red} {
-      width: 15px;
-      height: 15px;
-      border-radius: 15px;
+      width: 1rem;
+      height: 1rem;
+      border-radius: 1rem;
       background-color: ${colors.$googleRed};
     }
 
     .${yellow} {
-      width: 15px;
-      height: 15px;
-      border-radius: 15px;
+      width: 1rem;
+      height: 1rem;
+      border-radius: 1rem;
       background-color: ${colors.$googleYellow};
     }
 
     .${green} {
-      width: 15px;
-      height: 15px;
-      border-radius: 15px;
+      width: 1rem;
+      height: 1rem;
+      border-radius: 1rem;
       background-color: ${colors.$googleGreen};
     }
 
     .${statusText} {
-      font-size: 14px;
+      margin-right: 0.3rem;
+      font-size: 0.9rem;
       color: ${colors.$darkGrey};
-      margin-right: 5px;
     }
 
     .${statusContainer} {
-      position: absolute;
       display: flex;
+      position: absolute;
+      right: 1rem;
       align-items: center;
-      right: 20px;
     }
-
   `;
 
-  return { scenarioCard, title, tag, statusText, statusContainer, red, yellow, green };
+  return {
+    scenarioCard,
+    title,
+    tag,
+    statusText,
+    statusContainer,
+    red,
+    yellow,
+    green,
+  };
 };

--- a/packages/admin/src/components/Scenario/CardList/index.tsx
+++ b/packages/admin/src/components/Scenario/CardList/index.tsx
@@ -1,20 +1,20 @@
-import { menuContext, sidebarMenus } from "@admin/utils/menuContext";
+import { MenuContext, MenuConfig } from "@admin/utils/menuContext";
 import { noticeScenariosMocks, noticeGroupsMocks } from "@admin/__mocks__";
-import { scenarioConfig } from "@shared/types";
+import { ScenarioConfig } from "@shared/types";
 import { useContext } from "react";
 import Card from "../Card";
 import getStyle from "./style";
 
 export default function ScenarioCardList() {
+  const { status } = useContext(MenuContext);
   const style = getStyle();
-  const { status } = useContext(menuContext);
 
-  const filterScenario = (scenarios: scenarioConfig[], group: string) => {
+  const filterScenario = (scenarios: ScenarioConfig[], group: string) => {
     const scenarioGroup = scenarios.filter(
       (scenario) => scenario.group === group,
     );
     const viewScenario = scenarioGroup.filter((scenario) => {
-      const isAll = status === sidebarMenus[0];
+      const isAll = status === MenuConfig.all;
       const isSameStatus = scenario.status === status;
       return isAll || isSameStatus;
     });
@@ -33,7 +33,7 @@ export default function ScenarioCardList() {
                 <Card
                   className={style.card}
                   scenario={scenario}
-                  key={scenario.titleText}
+                  key={scenario.title}
                 />
               ))}
             </div>

--- a/packages/admin/src/components/Scenario/CardList/style.ts
+++ b/packages/admin/src/components/Scenario/CardList/style.ts
@@ -12,18 +12,17 @@ export default () => {
       justify-content: left;
       flex-wrap: wrap;
       align-items: flex-start;
-      margin: 5%;
+      margin: 3rem;
     }
 
     .${card} {
-      margin-left: 2%;
-      margin-right: 2%;
-      margin-top: 20px;
+      margin-left: 2rem;
+      margin-top: 2rem;
     }
 
     .${groupTitle} {
-      font-size: 30px;
-      margin-left: 5%;
+      font-size: 2rem;
+      margin-left: 3rem;
     }
   `;
 

--- a/packages/admin/src/globalStyle.ts
+++ b/packages/admin/src/globalStyle.ts
@@ -132,7 +132,6 @@ export default () => css`
     border-collapse: collapse;
     border-spacing: 0;
   }
-
   * {
     box-sizing: border-box;
   }

--- a/packages/admin/src/pages/Home/index.tsx
+++ b/packages/admin/src/pages/Home/index.tsx
@@ -2,28 +2,28 @@ import { useState } from "react";
 import { ScenarioCardList } from "@admin/components/Scenario";
 import Navigation from "@admin/components/Navigation";
 import {
-  menuContext,
-  menuContextConfig,
-  sidebarMenus,
+  MenuContext,
+  MenuContextConfig,
+  MenuConfig,
 } from "@admin/utils/menuContext";
 import getStyle from "./style";
 
 export default function Home() {
-  const [status, setStatus] = useState(sidebarMenus[0]);
-  const { main, mainTitle } = getStyle();
+  const [status, setStatus] = useState(MenuConfig.all);
+  const style = getStyle();
 
-  const contextObj: menuContextConfig = {
+  const contextObj: MenuContextConfig = {
     status,
     setContext: (newStatus) => setStatus(newStatus),
   };
 
   return (
-    <menuContext.Provider value={contextObj}>
+    <MenuContext.Provider value={contextObj}>
       <Navigation />
-      <main className={main}>
-        <h1 className={mainTitle}>CMI 스크래퍼 관리보드</h1>
+      <main className={style.main}>
+        <h1 className={style.mainTitle}>CMI 스크래퍼 관리보드</h1>
         <ScenarioCardList />
       </main>
-    </menuContext.Provider>
+    </MenuContext.Provider>
   );
 }

--- a/packages/admin/src/pages/Home/style.ts
+++ b/packages/admin/src/pages/Home/style.ts
@@ -5,14 +5,12 @@ export default () => {
   const mainTitle = cssHash();
 
   const main = css`
-    margin-left: 200px;
+    margin-left: 13rem;
 
     .${mainTitle} {
-      font-weight: 400;
+      margin: 8rem 0 5rem 3rem;
       font-size: 3rem;
-      margin-left: 5%;
-      margin-top: 15vh;
-      margin-bottom: 10vh;
+      font-weight: 400;
     }
   `;
 

--- a/packages/admin/src/utils/menuContext.ts
+++ b/packages/admin/src/utils/menuContext.ts
@@ -1,18 +1,23 @@
 import { createContext } from "react";
 
-export interface menuContextConfig {
-  status: string;
-  setContext: (status: string) => void;
+export enum MenuConfig {
+  all = "모두 보기",
+  running = "실행중",
+  waiting = "대기중",
+  error = "장애",
 }
 
-export const sidebarMenus: string[] = ["모두 보기", "실행중", "대기중", "장애"];
-
-export const defaultContext: menuContextConfig = {
-  status: sidebarMenus[0],
-
-  // TODO: 아래의 ESLint 규칙 config 파일에 적용하기
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  setContext: (status: string) => {},
+export type MenuContextConfig = {
+  status: string;
+  setContext: (status: MenuConfig) => void;
 };
 
-export const menuContext = createContext(defaultContext);
+export const defaultContext: MenuContextConfig = {
+  status: MenuConfig.all,
+
+  // TODO: React Context 대체할 전역 관리 툴 적용하기
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  setContext: (status) => {},
+};
+
+export const MenuContext = createContext(defaultContext);

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -2,11 +2,11 @@ export type Element = {
   className?: string;
 };
 
-export interface scenarioConfig {
+export type ScenarioConfig = {
   id: number;
-  titleText: string;
+  title: string;
   subTitle: string;
   status: string;
   group: string;
   tags: string[];
-}
+};


### PR DESCRIPTION
## 👀 이슈

- 리펙토링 대상 PR 이슈 #38
- 리펙토링 대상 PR #49

## 📌 개요

**관리자 페이지 UI 만들기** PR에서 받았던 코드리뷰를 바탕으로 리펙토링을 진행하였습니다.

## 👩‍💻 작업 사항

- `titleText` `title`로 다시 바꾸기.
  - 시나리오 객체에서 `titleText`를 `title`로 되돌림.
  - `getStyle()`에서 비구조화를 통해 가져오는 모든 코드를 비구조화를 사용하지 않는 방식으로 수정함(변수명이 겹쳐 불필요한 변수명을 사용하게 되는 상황을 방지하고자 함.).
- 한 파일 안에서만 사용하는 프롭 타입을 정의하는 경우 타입 이름을 `Props`로 통일.
- 타입 정의 시 `interface` 를 모두 `type`으로 바꿈.
- 타입 이름과 React Context 이름은 파스칼 표기법을 따라 첫 글자를 대문자로 바꿈.
- 사이드바에 표시되는 메뉴들을 타입스크립트의 `enum`으로 정의함. 이후 네비게이션 컴포넌트에서 enum에 정의된 각 메뉴들을 리스트로 직접 만들어서 사용하도록 함.
- 브라우저의 폰트 크기 설정을 존중할 수 있는 `rem` 단위 사용하기([관련 내용 링크](https://brunch.co.kr/@clay1987/170)).
- 이모션의 `cx` 함수 사용할 때 삼항연산자 대신 공식문서에서 권장하는 방법으로 조건부 클래스 네임 사용하기.
- NAVER CSS 속성 순서 컨벤션을 참고하여 CSS 속성 정리.

## ✅ 참고 사항

UI 관련하여 바뀐 부분은 없습니다.