### PR TITLE
[admin] google font 적용 및 select 태그 스타일 추가

### DIFF
--- a/packages/admin/public/index.html
+++ b/packages/admin/public/index.html
@@ -3,6 +3,13 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
+
     <title>admin</title>
   </head>
   <body>

--- a/packages/admin/src/App.tsx
+++ b/packages/admin/src/App.tsx
@@ -3,6 +3,7 @@ import { Global } from "@emotion/react";
 import Home from "src/pages/Home";
 import { Provider } from "react-redux";
 import getGlobalStyle from "@shared/styles/globalStyle";
+import getAdminStyle from "src/adminStyle";
 import Login from "./pages/Login";
 import { store } from "./store";
 
@@ -10,6 +11,7 @@ function App() {
   return (
     <Provider store={store}>
       <Global styles={getGlobalStyle()} />
+      <Global styles={getAdminStyle()} />
       <BrowserRouter>
         <Switch>
           <Route path="/login" component={Login} />

--- a/packages/admin/src/adminStyle.ts
+++ b/packages/admin/src/adminStyle.ts
@@ -1,0 +1,7 @@
+import { css } from "@emotion/react";
+
+export default () => css`
+  body {
+    font-family: "Roboto", sans-serif;
+  }
+`;

--- a/packages/admin/src/components/Scenario/ScenarioCard/style.ts
+++ b/packages/admin/src/components/Scenario/ScenarioCard/style.ts
@@ -42,7 +42,7 @@ export default ({ statusColor }: Props) => {
     background-color: ${colors.$white};
 
     :hover {
-      outline: 0.2rem solid ${colors.$lightBlue};
+      box-shadow: 0 0 0 0.2rem ${colors.$lightBlue};
       cursor: pointer;
     }
 

--- a/packages/admin/src/components/Selector/index.tsx
+++ b/packages/admin/src/components/Selector/index.tsx
@@ -40,14 +40,14 @@ export default function Selector() {
   };
 
   return (
-    <ul className={style.selectorContainer}>
+    <ul className={style.selectContainer}>
       {scraper === ScraperType.Notice && (
         <li>
-          <label htmlFor="groupSelector">
+          <label htmlFor="groupSelector" className={style.label}>
             그룹 필터
             <select
               onChange={handleGroupChange}
-              className={style.selector}
+              className={style.select}
               id="groupSelector"
             >
               <option value="모두보기" key="모두보기">
@@ -67,7 +67,7 @@ export default function Selector() {
           상태 필터
           <select
             onChange={handleStatusChange}
-            className={style.selector}
+            className={style.select}
             id="statusSelector"
           >
             <option value={StatusType.All}>{StatusType.All}</option>

--- a/packages/admin/src/components/Selector/style.ts
+++ b/packages/admin/src/components/Selector/style.ts
@@ -1,21 +1,27 @@
 import { css } from "@emotion/css";
+import { colors } from "@shared/styles/color";
 import { hashClassNames } from "src/utils/hash";
 
 export default () => {
-  const hashedStyle = hashClassNames([ "selector" ]);
-  const { selector } = hashedStyle;
+  const hashedStyle = hashClassNames([ "select", "label", "arrowIcon" ]);
+  const { label, select, arrowIcon } = hashedStyle;
 
-  const selectorContainer = css`
+  const selectContainer = css`
     display: flex;
     margin-left: 3rem;
 
-    .${selector} {
+    .${select} {
       height: 2rem;
       padding: 0.5rem;
       margin: 0 1rem;
       border: none;
+      border-radius: 0.7rem;
+      :hover {
+        box-shadow: 0 0 0 0.1rem ${colors.$lightBlue};
+        cursor: pointer;
+      }
     }
   `;
 
-  return { selectorContainer, selector };
+  return { selectContainer, select, label, arrowIcon };
 };

--- a/packages/shared/src/styles/globalStyle.ts
+++ b/packages/shared/src/styles/globalStyle.ts
@@ -132,6 +132,12 @@ export default () => css`
     border-collapse: collapse;
     border-spacing: 0;
   }
+  select {
+    appearance: none;
+  }
+  select:focus {
+    outline: none;
+  }
   * {
     box-sizing: border-box;
   }


### PR DESCRIPTION
## 📌 개요

그동안 크롬 브라우저로만 어드민 페이지를 보다가 사파리로 접속하니 기본 폰트와 select 태그 스타일이 매우 이상하였습니다. 따라서 google font를 적용하고 select에도 커스텀 스타일을 적용했습니다.

+ 크롬에서는 outline을 태그의 border-radius에 맞춰서 둥글게 만들어주는데, 사파리에는 없습니다.

## 👩‍💻 작업 사항

- google 폰트 적용
- select 태그 기본 스타일 제거 & 커스텀 스타일 추가
- outline 대신 box-shadow를 응용하여 시나리오 카드 호버 시 외곽선이 생기도록 함.

## ✅ 참고 사항

적용 전 사진

<img width="1392" alt="스크린샷 2021-12-18 오후 5 03 37" src="https://user-images.githubusercontent.com/71015915/146634186-82a4aeb5-f339-405e-993a-318c1c682041.png">

적용 후 사진

<img width="1392" alt="스크린샷 2021-12-18 오후 4 56 35" src="https://user-images.githubusercontent.com/71015915/146634198-43d3587b-1f79-41d9-a8eb-5f83d179e988.png">
