### PR TITLE
[admin] 시나리오 카드 상태 수정 및 gray 컬러 통합

### DIFF
--- a/packages/admin/src/__mockData__/collegeScheduleScenarios.ts
+++ b/packages/admin/src/__mockData__/collegeScheduleScenarios.ts
@@ -2,7 +2,7 @@ const scenarios = [
   {
     id: 1,
     title: "학사일정",
-    status: "실행중",
+    status: "clean",
     tags: [ "테스트 태그" ],
   },
 ];

--- a/packages/admin/src/__mockData__/domitoryRestaurantScenarios.ts
+++ b/packages/admin/src/__mockData__/domitoryRestaurantScenarios.ts
@@ -3,19 +3,19 @@ const scenarios = [
     id: 1,
     title: "개성재",
     tags: [ "테스트 태그" ],
-    status: "실행중",
+    status: "clean",
   },
   {
     id: 2,
     title: "양진재",
     tags: [ "테스트 태그" ],
-    status: "대기중",
+    status: "warning",
   },
   {
     id: 3,
     title: "양성재",
     tags: [ "테스트 태그" ],
-    status: "장애",
+    status: "error",
   },
 ];
 

--- a/packages/admin/src/__mockData__/noticeScenarios.ts
+++ b/packages/admin/src/__mockData__/noticeScenarios.ts
@@ -14,7 +14,7 @@ const scenarios = [
       "보입니다",
     ],
     group: "전자정보대학",
-    status: "실행중",
+    status: "clean",
   },
   {
     id: 2,
@@ -22,7 +22,7 @@ const scenarios = [
     subTitle: "공지사항",
     tags: [ "전자정보대학" ],
     group: "전자정보대학",
-    status: "대기중",
+    status: "excluded",
   },
   {
     id: 3,
@@ -30,7 +30,7 @@ const scenarios = [
     subTitle: "공지사항",
     tags: [ "전자정보대학" ],
     group: "전자정보대학",
-    status: "장애",
+    status: "warning",
   },
   {
     id: 4,
@@ -38,7 +38,7 @@ const scenarios = [
     subTitle: "공지사항",
     tags: [ "전자정보대학" ],
     group: "전자정보대학",
-    status: "장애",
+    status: "error",
   },
   {
     id: 5,
@@ -46,7 +46,7 @@ const scenarios = [
     subTitle: "공지사항",
     tags: [ "전자정보대학" ],
     group: "전자정보대학",
-    status: "장애",
+    status: "error",
   },
   {
     id: 6,
@@ -54,7 +54,7 @@ const scenarios = [
     subTitle: "공지사항",
     tags: [ "전자정보대학" ],
     group: "전자정보대학",
-    status: "장애",
+    status: "error",
   },
   {
     id: 7,
@@ -62,7 +62,7 @@ const scenarios = [
     subTitle: "공지사항",
     tags: [ "사회과학대학" ],
     group: "사회과학대학",
-    status: "실행중",
+    status: "clean",
   },
   {
     id: 8,
@@ -70,7 +70,7 @@ const scenarios = [
     subTitle: "공지사항",
     tags: [ "사회과학대학" ],
     group: "사회과학대학",
-    status: "장애",
+    status: "error",
   },
   {
     id: 9,
@@ -78,7 +78,7 @@ const scenarios = [
     subTitle: "공지사항",
     tags: [ "사회과학대학" ],
     group: "사회과학대학",
-    status: "장애",
+    status: "error",
   },
   {
     id: 10,
@@ -86,7 +86,7 @@ const scenarios = [
     subTitle: "공지사항",
     tags: [ "인문대학" ],
     group: "인문대학",
-    status: "실행중",
+    status: "clean",
   },
 ];
 

--- a/packages/admin/src/__mockData__/studentRestaurantScenarios.ts
+++ b/packages/admin/src/__mockData__/studentRestaurantScenarios.ts
@@ -3,19 +3,19 @@ const scenarios = [
     id: 1,
     title: "한빛식당",
     tags: [ "테스트 태그" ],
-    status: "실행중",
+    status: "clean",
   },
   {
     id: 2,
     title: "별빛식당",
     tags: [ "테스트 태그" ],
-    status: "대기중",
+    status: "warning",
   },
   {
     id: 3,
     title: "은화수식당",
     tags: [ "테스트 태그" ],
-    status: "장애",
+    status: "error",
   },
 ];
 

--- a/packages/admin/src/components/Scenario/ScenarioCard/index.tsx
+++ b/packages/admin/src/components/Scenario/ScenarioCard/index.tsx
@@ -15,16 +15,20 @@ export default function ScenarioCard({ className, scenario }: Props & Element) {
   const style = getStyle({ statusColor: color });
 
   useEffect(() => {
-    if (status === StatusType.Running) {
+    if (status === StatusType.Clean) {
       setColor(Colors.Green);
       return;
     }
-    if (status === StatusType.Waiting) {
+    if (status === StatusType.Warning) {
       setColor(Colors.Yellow);
       return;
     }
     if (status === StatusType.Error) {
       setColor(Colors.Red);
+      return;
+    }
+    if (status === StatusType.Excluded) {
+      setColor(Colors.Gray);
     }
   }, [ status ]);
 

--- a/packages/admin/src/components/Scenario/ScenarioCard/style.ts
+++ b/packages/admin/src/components/Scenario/ScenarioCard/style.ts
@@ -17,7 +17,7 @@ const colorSelector = (color: Colors) => {
   if (color === Colors.Green) return colors.$googleGreen;
   if (color === Colors.Yellow) return colors.$googleYellow;
   if (color === Colors.Red) return colors.$googleRed;
-  return colors.$darkGrey;
+  return colors.$gray.$500;
 };
 
 export default ({ statusColor }: Props) => {
@@ -74,7 +74,7 @@ export default ({ statusColor }: Props) => {
     .${statusText} {
       margin-right: 0.3rem;
       font-size: 0.9rem;
-      color: ${colors.$darkGrey};
+      color: ${colors.$gray.$500};
     }
 
     .${statusContainer} {

--- a/packages/admin/src/components/Scenario/ScenarioCard/style.ts
+++ b/packages/admin/src/components/Scenario/ScenarioCard/style.ts
@@ -6,6 +6,7 @@ export enum Colors {
   Green = "Green",
   Yellow = "Yellow",
   Red = "Red",
+  Gray = "Gray",
 }
 
 interface Props {
@@ -15,7 +16,8 @@ interface Props {
 const colorSelector = (color: Colors) => {
   if (color === Colors.Green) return colors.$googleGreen;
   if (color === Colors.Yellow) return colors.$googleYellow;
-  return colors.$googleRed;
+  if (color === Colors.Red) return colors.$googleRed;
+  return colors.$darkGrey;
 };
 
 export default ({ statusColor }: Props) => {

--- a/packages/admin/src/components/Selector/index.tsx
+++ b/packages/admin/src/components/Selector/index.tsx
@@ -26,16 +26,20 @@ export default function Selector() {
       dispatch(setStatus(StatusType.All));
       return;
     }
-    if (value === StatusType.Running) {
-      dispatch(setStatus(StatusType.Running));
+    if (value === StatusType.Clean) {
+      dispatch(setStatus(StatusType.Clean));
       return;
     }
-    if (value === StatusType.Waiting) {
-      dispatch(setStatus(StatusType.Waiting));
+    if (value === StatusType.Warning) {
+      dispatch(setStatus(StatusType.Warning));
       return;
     }
     if (value === StatusType.Error) {
       dispatch(setStatus(StatusType.Error));
+      return;
+    }
+    if (value === StatusType.Excluded) {
+      dispatch(setStatus(StatusType.Excluded));
     }
   };
 
@@ -71,9 +75,10 @@ export default function Selector() {
             id="statusSelector"
           >
             <option value={StatusType.All}>{StatusType.All}</option>
-            <option value={StatusType.Running}>{StatusType.Running}</option>
-            <option value={StatusType.Waiting}>{StatusType.Waiting}</option>
+            <option value={StatusType.Clean}>{StatusType.Clean}</option>
+            <option value={StatusType.Warning}>{StatusType.Warning}</option>
             <option value={StatusType.Error}>{StatusType.Error}</option>
+            <option value={StatusType.Excluded}>{StatusType.Excluded}</option>
           </select>
         </label>
       </li>

--- a/packages/admin/src/store/statusType.ts
+++ b/packages/admin/src/store/statusType.ts
@@ -1,6 +1,7 @@
 export enum StatusType {
   All = "모두",
-  Running = "실행중",
-  Waiting = "대기중",
-  Error = "장애",
+  Clean = "clean",
+  Warning = "warning",
+  Error = "error",
+  Excluded = "excluded",
 }

--- a/packages/shared/src/styles/color.ts
+++ b/packages/shared/src/styles/color.ts
@@ -2,15 +2,15 @@ const colors = {
   $black: "#222",
   $primary: "#862D4E",
   $gray: {
+    $300: "#F4F5F7",
     $400: "#BDBDBD",
+    $500: "#686B72",
   },
   $white: "#fff",
   $lightBlue: "#0052CC",
   $googleRed: "#E24134",
   $googleYellow: "#F3B606",
   $googleGreen: "#31A350",
-  $grey: "#F4F5F7",
-  $darkGrey: "#686B72",
   $darkNavy: "#091E42",
 };
 

--- a/packages/shared/src/styles/globalStyle.ts
+++ b/packages/shared/src/styles/globalStyle.ts
@@ -111,7 +111,7 @@ export default () => css`
   }
   body {
     line-height: 1;
-    background-color: ${colors.$grey};
+    background-color: ${colors.$gray.$300};
   }
   ol,
   ul {


### PR DESCRIPTION
## 👀 이슈

resolve #77 

## 📌 개요

시나리오 카드의 데이터 구조가 변경됨에 따라 시나리오 카드가 가질 수 있는 상태를 알맞게 변경했습니다.

<변경전>
- 실행중
- 대기중
- 장애

<변경후>
- clean
- warning
- error
- excluded

또한, shared 디렉토리의 color에서 gray와 grey(영국식 표현이라고 하네요)가 섞여 있고, 숫자로 채도를 매기는 방식을 사용하면서도 darkgray 색이 별도로 존재하는 등  혼란스러운 부분이 있어 통일하였습니다.

## 👩‍💻 작업 사항

- 시나리오 카드 상태를 새로운 상태 구조로 변경했습니다.
- 회색 컬러 변수를 통일했습니다.

## ✅ 참고 사항

<img width="817" alt="스크린샷 2021-12-19 오후 5 10 26" src="https://user-images.githubusercontent.com/71015915/146668196-6a4bd413-f331-4f2c-99b3-e20b2ca27b70.png">


