### PR TITLE
[admin] webpack 설정 변경

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "ts-node-dev": "^1.1.8",
     "typescript": "^4.5.2",
     "webpack": "^5.65.0",
+    "webpack-bundle-analyzer": "^4.5.0",
     "webpack-cli": "^4.9.1",
     "webpack-dev-server": "^4.6.0"
   },

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "start:admin": "lerna run --scope admin start",
     "dev:admin": "lerna run --scope admin dev --stream",
     "build:admin": "lerna run --scope admin build",
+    "analyze:admin": "lerna run --scope admin build -- --analyze",
     "start:mobile": "lerna run --scope mobile start",
     "dev:mobile": "lerna run --scope mobile dev --stream",
     "build:mobile": "lerna run --scope mobile build --stream",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "start:admin": "lerna run --scope admin start",
     "dev:admin": "lerna run --scope admin dev --stream",
     "build:admin": "lerna run --scope admin build",
-    "analyze:admin": "lerna run --scope admin build -- --analyze",
+    "analyze:admin": "lerna run --scope admin analyze",
     "start:mobile": "lerna run --scope mobile start",
     "dev:mobile": "lerna run --scope mobile dev --stream",
     "build:mobile": "lerna run --scope mobile build --stream",

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -19,7 +19,8 @@
   "scripts": {
     "dev": "webpack-dev-server --mode development",
     "build": "webpack --progress --mode production",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "analyze": "yarn build --analyze"
   },
   "bugs": {
     "url": "https://github.com/CMI-OSS/cbnu-alrami/issues"

--- a/packages/admin/webpack.config.js
+++ b/packages/admin/webpack.config.js
@@ -3,6 +3,10 @@ const path = require("path");
 const webpack = require("webpack");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const { CleanWebpackPlugin } = require("clean-webpack-plugin");
+const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
+
+const isAnalyze = process.argv.includes('--analyze');
+const prod = process.env.NODE_ENV || 'production';
 
 module.exports = {
   devServer: {
@@ -12,13 +16,15 @@ module.exports = {
     open: true,
   },
   entry: {
-    main: "./src/index.tsx",
+    main: "./src/index",
   },
   output: {
-    filename: "bundle.js",
+    filename: "[name].[chunkhash:8].bundle.js",
+    chunkFilename: '[name].[chunkhash:8].bundle.js',
     path: path.resolve(__dirname, "./build"),
+    clean: true
   },
-  devtool: "eval-cheap-source-map",
+  devtool:  prod? 'cheap-source-map': 'eval-cheap-source-map',
   resolve: {
     extensions: [ ".tsx", ".ts", ".js" ],
     alias: {
@@ -36,6 +42,7 @@ module.exports = {
       },
       {
         test: /\.css$/,
+        exclude: "/node_modules/",
         use: [ "style-loader", "css-loader" ],
       },
       {
@@ -52,6 +59,7 @@ module.exports = {
     new HtmlWebpackPlugin({
       template: "./public/index.html",
     }),
-    new webpack.HotModuleReplacementPlugin(),
+  ...isAnalyze? [ new BundleAnalyzerPlugin() ] : [],
+  new webpack.HotModuleReplacementPlugin(),
   ],
 };


### PR DESCRIPTION
## 👀 이슈
- 따로 이슈등록을 하진 않아서.. 이슈 번호는 적지 않았습니다.

## 📌 개요
webpack에서 번들링 크기를 줄이기 위한 파일 설정을 진행하였습니다.

## 👩‍💻 작업 사항
- `webpack.config.js`에서 build된 파일의 크기를 시각화해줄 수 있는 `build-analyzer-plugin`를 설치하고, 시각화 부분만 확인할 수 있는 스크립트를 package.json에 추가하였습니다.
- `production`모드인지 아닌지에 따라서 devtool이 다르게 동작하도록 설정하였습니다. 
- `entry`에서 확장자는 추가할 필요가 없어서 제거해주었습니다.

## ✅ 참고 사항
- 번들링 파일이 4.81MIB이었는데 지금은 240KB로 줄일 수 있었습니다. 
<img width="1173" alt="스크린샷 2021-12-20 오후 10 37 38" src="https://user-images.githubusercontent.com/22065725/146775599-81675ff0-9b83-44b7-99a0-841366945adc.png">

- 여러가지 의논할 사항이 있습니다.
   - `devServer`에서 proxy 속성을 넣어주지 않은 이유가 궁금합니다. ( 제가 webpack을 이용해서 api 연결을 할 때 proxy 속성을 추가해주어야 cors 에러가 발생하지 않았어서.. 혹시 다른 방법이 있는건지 궁금합니다.)
   - `module`에서 `file-loader`의 확장자(ex. png, svg...)를 더 추가할 필요가 있을 것 같아서 여쭤봅니다.
   - `resolve`의 `alias` 속성은 디렉토리가 더 세분화가 된다면 수정하겠습니다.
   - `entry`의 경우는 진입점이 한 곳이라서 `splitChunk` 속성을 따로 추가하진 않았습니다. (진입점이 여러 개일 경우 코드 스플리팅의 방법으로 좀 더 최적화할 수 있을 것 같습니다.)
   - 참고했던 **블로그 링크**입니다! 
   - [webpack-devtool](https://perfectacle.github.io/2016/11/14/Webpack-devtool-option-Performance/)
   - [webpack-chunk](https://www.zerocho.com/category/Webpack/post/58ad4c9d1136440018ba44e7)
   - [webpack 공식 홈페이지](https://webpack.js.org/)
   - [webpack naver d2](https://d2.naver.com/helloworld/0239818)
   - [stat size vs parsed size issue](https://github.com/webpack-contrib/webpack-bundle-analyzer/issues/228)