### PR TITLE
[mobile] webpack 설정 변경

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "start:mobile": "lerna run --scope mobile start",
     "dev:mobile": "lerna run --scope mobile dev --stream",
     "build:mobile": "lerna run --scope mobile build --stream",
+    "analyze:mobile": "lerna run --scope mobile analyze",
     "start:scraper": "lerna run --scope scraper start",
     "dev:scraper": "lerna run --scope scraper dev --stream",
     "start:server": "lerna run --scope server start",

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -5,7 +5,8 @@
   "license": "MIT",
   "scripts": {
     "dev": "webpack-dev-server --mode development",
-    "build": "webpack --progress --mode production"
+    "build": "webpack --progress --mode production",
+    "analyze": "yarn build --analyze"
   },
   "dependencies": {
     "react": "^17.0.2",

--- a/packages/mobile/webpack.config.js
+++ b/packages/mobile/webpack.config.js
@@ -3,6 +3,10 @@ const path = require("path");
 const webpack = require("webpack");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const { CleanWebpackPlugin } = require("clean-webpack-plugin");
+const { BundleAnalyzerPlugin } = require("webpack-bundle-analyzer");
+
+const isAnalyze = process.argv.includes("--analyze");
+const prod = process.env.NODE_ENV || "production";
 
 module.exports = {
   devServer: {
@@ -12,13 +16,15 @@ module.exports = {
     open: true,
   },
   entry: {
-    main: "./src/index.tsx",
+    main: "./src/index",
   },
   output: {
-    filename: "bundle.js",
+    filename: "[name].[chunkhash:8].bundle.js",
+    chunkFilename: "[name].[chunkhash:8].bundle.js",
     path: path.resolve(__dirname, "./dist"),
+    clean: true,
   },
-  devtool: "eval-cheap-source-map",
+  devtool: prod ? "cheap-source-map" : "eval-cheap-source-map",
   resolve: {
     extensions: [".tsx", ".ts", ".js"],
     alias: {
@@ -52,6 +58,7 @@ module.exports = {
     new HtmlWebpackPlugin({
       template: "./public/index.html",
     }),
+    ...(isAnalyze ? [new BundleAnalyzerPlugin()] : []),
     new webpack.HotModuleReplacementPlugin(),
   ],
 };


### PR DESCRIPTION
## 👀 이슈
- 따로 이슈등록을 하진 않아서.. 이슈 번호는 적지 않았습니다.

## 📌 개요
mobile packages - webpack에서 번들링 크기를 줄이기 위한 파일 설정을 진행하였습니다.

## 👩‍💻 작업 사항
- `webpack.config.js`에서 build된 파일의 크기를 시각화해줄 수 있는 `build-analyzer-plugin`를 설치하고, 시각화 부분만 확인할 수 있는 스크립트를 package.json에 추가하였습니다.
- `production`모드인지 아닌지에 따라서 devtool이 다르게 동작하도록 설정하였습니다. 
- `entry`에서 확장자는 추가할 필요가 없어서 제거해주었습니다.

## ✅ 참고 사항
- `prettier`를 admin쪽에서 제스가 해줘서 mobile만 설정해주었습니다. 
