### PR TITLE
[admin] 스크래퍼 관리 UI

### DIFF
--- a/packages/admin/src/__mockData__/collegeScheduleScenarioQueue.ts
+++ b/packages/admin/src/__mockData__/collegeScheduleScenarioQueue.ts
@@ -1,4 +1,4 @@
-import { ScenarioQueueType, ExcutionLogType } from "@shared/types";
+import { ScenarioQueueType, ExcutionLogType } from "src/types";
 
 const queue: ScenarioQueueType[] = [
   {
@@ -14,14 +14,14 @@ const queue: ScenarioQueueType[] = [
 ];
 
 const log: ExcutionLogType = {
-  scraper: "학사일정 목록",
-  result: "스크래핑 성공 및 종료",
+  scraperState: "running",
+  scenarioState: "clean",
+  scenarioResult: "success",
   commands: [
     "GITHUB_TOKEN Permissions",
     "Secret source: Actions",
     "Prepare workflow directory",
     "Prepare all required actions",
-    "Getting action download info",
     "Download action repository 'actions/checkout@v12' (SHA:ec3a7ce1137a93b817d10a272cb61118579)",
   ],
 };

--- a/packages/admin/src/__mockData__/collegeScheduleScenarioQueue.ts
+++ b/packages/admin/src/__mockData__/collegeScheduleScenarioQueue.ts
@@ -1,0 +1,29 @@
+import { ScenarioQueueType, ExcutionLogType } from "@shared/types";
+
+const queue: ScenarioQueueType[] = [
+  {
+    id: 1,
+    title: "2021년 학사일정",
+    turn: "prev",
+  },
+  {
+    id: 2,
+    title: "2022년 학사일정",
+    turn: "current",
+  },
+];
+
+const log: ExcutionLogType = {
+  scraper: "학사일정 목록",
+  result: "스크래핑 성공 및 종료",
+  commands: [
+    "GITHUB_TOKEN Permissions",
+    "Secret source: Actions",
+    "Prepare workflow directory",
+    "Prepare all required actions",
+    "Getting action download info",
+    "Download action repository 'actions/checkout@v12' (SHA:ec3a7ce1137a93b817d10a272cb61118579)",
+  ],
+};
+
+export default { queue, log };

--- a/packages/admin/src/__mockData__/domitoryRestarantScenarioQueue.ts
+++ b/packages/admin/src/__mockData__/domitoryRestarantScenarioQueue.ts
@@ -1,0 +1,34 @@
+import { ScenarioQueueType, ExcutionLogType } from "@shared/types";
+
+const queue: ScenarioQueueType[] = [
+  {
+    id: 1,
+    title: "개성재",
+    turn: "prev",
+  },
+  {
+    id: 2,
+    title: "양진재",
+    turn: "current",
+  },
+  {
+    id: 3,
+    title: "양성재",
+    turn: "next",
+  },
+];
+
+const log: ExcutionLogType = {
+  scraper: "기숙사 목록",
+  result: "스크래핑 성공 및 다음 시나리오 대기중",
+  commands: [
+    "GITHUB_TOKEN Permissions",
+    "Secret source: Actions",
+    "Prepare workflow directory",
+    "Prepare all required actions",
+    "Getting action download info",
+    "Download action repository 'actions/checkout@v12' (SHA:ec3a7ce1137a93b817d10a272cb61118579)",
+  ],
+};
+
+export default { queue, log };

--- a/packages/admin/src/__mockData__/domitoryRestarantScenarioQueue.ts
+++ b/packages/admin/src/__mockData__/domitoryRestarantScenarioQueue.ts
@@ -1,4 +1,4 @@
-import { ScenarioQueueType, ExcutionLogType } from "@shared/types";
+import { ScenarioQueueType, ExcutionLogType } from "src/types";
 
 const queue: ScenarioQueueType[] = [
   {
@@ -19,14 +19,14 @@ const queue: ScenarioQueueType[] = [
 ];
 
 const log: ExcutionLogType = {
-  scraper: "기숙사 목록",
-  result: "스크래핑 성공 및 다음 시나리오 대기중",
+  scraperState: "pause",
+  scenarioState: "warning",
+  scenarioResult: "fail",
   commands: [
     "GITHUB_TOKEN Permissions",
     "Secret source: Actions",
     "Prepare workflow directory",
     "Prepare all required actions",
-    "Getting action download info",
     "Download action repository 'actions/checkout@v12' (SHA:ec3a7ce1137a93b817d10a272cb61118579)",
   ],
 };

--- a/packages/admin/src/__mockData__/index.ts
+++ b/packages/admin/src/__mockData__/index.ts
@@ -1,11 +1,20 @@
 import noticeScenariosMockData from "./noticeScenarios";
 import studentRestaurantScenariosMockData from "./studentRestaurantScenarios";
 import domitoryRestaurantScenariosMockData from "./domitoryRestaurantScenarios";
-import colleageScheduleMockData from "./collegeScheduleScenarios";
+import collegeScheduleMockData from "./collegeScheduleScenarios";
+
+import noticeScenarioQueue from "./noticeScenarioQueue";
+import studentScenarioQueue from "./studentRestaurantScenarioQueue";
+import domitoryScenarioQueue from "./domitoryRestarantScenarioQueue";
+import scheduleScenarioQueue from "./collegeScheduleScenarioQueue";
 
 export {
   noticeScenariosMockData,
   studentRestaurantScenariosMockData,
   domitoryRestaurantScenariosMockData,
-  colleageScheduleMockData,
+  collegeScheduleMockData,
+  scheduleScenarioQueue,
+  domitoryScenarioQueue,
+  noticeScenarioQueue,
+  studentScenarioQueue,
 };

--- a/packages/admin/src/__mockData__/noticeScenarioQueue.ts
+++ b/packages/admin/src/__mockData__/noticeScenarioQueue.ts
@@ -1,0 +1,34 @@
+import { ScenarioQueueType, ExcutionLogType } from "@shared/types";
+
+const queue: ScenarioQueueType[] = [
+  {
+    id: 1,
+    title: "전기공학부",
+    turn: "prev",
+  },
+  {
+    id: 2,
+    title: "소프트웨어학과",
+    turn: "current",
+  },
+  {
+    id: 3,
+    title: "컴퓨터공학과",
+    turn: "next",
+  },
+];
+
+const log: ExcutionLogType = {
+  scraper: "공지사항 목록",
+  result: "스크래핑 실패 및 일시정지",
+  commands: [
+    "GITHUB_TOKEN Permissions",
+    "Secret source: Actions",
+    "Prepare workflow directory",
+    "Prepare all required actions",
+    "Getting action download info",
+    "Download action repository 'actions/checkout@v12' (SHA:ec3a7ce1137a93b817d10a272cb61118579)",
+  ],
+};
+
+export default { queue, log };

--- a/packages/admin/src/__mockData__/noticeScenarioQueue.ts
+++ b/packages/admin/src/__mockData__/noticeScenarioQueue.ts
@@ -1,4 +1,4 @@
-import { ScenarioQueueType, ExcutionLogType } from "@shared/types";
+import { ScenarioQueueType, ExcutionLogType } from "src/types";
 
 const queue: ScenarioQueueType[] = [
   {
@@ -19,14 +19,14 @@ const queue: ScenarioQueueType[] = [
 ];
 
 const log: ExcutionLogType = {
-  scraper: "공지사항 목록",
-  result: "스크래핑 실패 및 일시정지",
+  scraperState: "stop",
+  scenarioState: "excluded",
+  scenarioResult: "fail",
   commands: [
     "GITHUB_TOKEN Permissions",
     "Secret source: Actions",
     "Prepare workflow directory",
     "Prepare all required actions",
-    "Getting action download info",
     "Download action repository 'actions/checkout@v12' (SHA:ec3a7ce1137a93b817d10a272cb61118579)",
   ],
 };

--- a/packages/admin/src/__mockData__/studentRestaurantScenarioQueue.ts
+++ b/packages/admin/src/__mockData__/studentRestaurantScenarioQueue.ts
@@ -1,4 +1,4 @@
-import { ScenarioQueueType, ExcutionLogType } from "@shared/types";
+import { ScenarioQueueType, ExcutionLogType } from "src/types";
 
 const queue: ScenarioQueueType[] = [
   {
@@ -19,14 +19,14 @@ const queue: ScenarioQueueType[] = [
 ];
 
 const log: ExcutionLogType = {
-  scraper: "학생 식당 목록",
-  result: "스크래핑 성공 및 다음 시나리오 대기중",
+  scraperState: "error",
+  scenarioState: "error",
+  scenarioResult: "fail",
   commands: [
     "GITHUB_TOKEN Permissions",
     "Secret source: Actions",
     "Prepare workflow directory",
     "Prepare all required actions",
-    "Getting action download info",
     "Download action repository 'actions/checkout@v12' (SHA:ec3a7ce1137a93b817d10a272cb61118579)",
   ],
 };

--- a/packages/admin/src/__mockData__/studentRestaurantScenarioQueue.ts
+++ b/packages/admin/src/__mockData__/studentRestaurantScenarioQueue.ts
@@ -1,0 +1,34 @@
+import { ScenarioQueueType, ExcutionLogType } from "@shared/types";
+
+const queue: ScenarioQueueType[] = [
+  {
+    id: 1,
+    title: "한빛식당",
+    turn: "prev",
+  },
+  {
+    id: 2,
+    title: "별빛식당",
+    turn: "current",
+  },
+  {
+    id: 3,
+    title: "은화수식당",
+    turn: "next",
+  },
+];
+
+const log: ExcutionLogType = {
+  scraper: "학생 식당 목록",
+  result: "스크래핑 성공 및 다음 시나리오 대기중",
+  commands: [
+    "GITHUB_TOKEN Permissions",
+    "Secret source: Actions",
+    "Prepare workflow directory",
+    "Prepare all required actions",
+    "Getting action download info",
+    "Download action repository 'actions/checkout@v12' (SHA:ec3a7ce1137a93b817d10a272cb61118579)",
+  ],
+};
+
+export default { queue, log };

--- a/packages/admin/src/components/Manager/ExcutionLog/index.tsx
+++ b/packages/admin/src/components/Manager/ExcutionLog/index.tsx
@@ -1,0 +1,33 @@
+import { ExcutionLogType } from "@shared/types";
+import getStyle from "./style";
+
+interface Props {
+  log: ExcutionLogType;
+}
+
+export default function ExcutionLog({ log }: Props) {
+  const style = getStyle();
+
+  return (
+    <section className={style.excutionLog}>
+      <h2 className={style.excutionLogTitle}>실행 로그</h2>
+      <div className={style.excutionBox}>
+        {Object.entries(log).map((content) => {
+          if (content[0] === "commands" && typeof content[1] === "object") {
+            return content[1].map((command: string) => (
+              <p key={command} className={style.log}>
+                {command}
+              </p>
+            ));
+          }
+
+          return (
+            <p key={content[0] + content[1]} className={style.log}>
+              {content[1]}
+            </p>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/packages/admin/src/components/Manager/ExcutionLog/index.tsx
+++ b/packages/admin/src/components/Manager/ExcutionLog/index.tsx
@@ -1,4 +1,4 @@
-import { ExcutionLogType } from "@shared/types";
+import { ExcutionLogType } from "src/types";
 import getStyle from "./style";
 
 interface Props {

--- a/packages/admin/src/components/Manager/ExcutionLog/style.ts
+++ b/packages/admin/src/components/Manager/ExcutionLog/style.ts
@@ -12,10 +12,8 @@ export default () => {
   const excutionLog = css`
     display: flex;
     flex-direction: column;
-    position: relative;
     width: 43rem;
     min-height: 16rem;
-    margin: 0 0 2rem 7rem;
     padding: 1.5rem;
     box-shadow: rgba(17, 17, 26, 0.05) 0px 1px 0px,
       rgba(17, 17, 26, 0.1) 0px 0px 8px;
@@ -33,7 +31,6 @@ export default () => {
       .${log} {
         margin: 0.1rem 0;
         font-size: 1rem;
-        line-break: auto;
       }
     }
   `;

--- a/packages/admin/src/components/Manager/ExcutionLog/style.ts
+++ b/packages/admin/src/components/Manager/ExcutionLog/style.ts
@@ -1,0 +1,42 @@
+import { css } from "@emotion/css";
+import { colors } from "@shared/styles/color";
+import { hashClassNames } from "src/lib/hash";
+
+export default () => {
+  const { excutionLogTitle, excutionBox, log } = hashClassNames([
+    "excutionLogTitle",
+    "excutionBox",
+    "log",
+  ]);
+
+  const excutionLog = css`
+    display: flex;
+    flex-direction: column;
+    position: relative;
+    width: 43rem;
+    min-height: 16rem;
+    margin: 0 0 2rem 7rem;
+    padding: 1.5rem;
+    box-shadow: rgba(17, 17, 26, 0.05) 0px 1px 0px,
+      rgba(17, 17, 26, 0.1) 0px 0px 8px;
+    border-radius: 1rem;
+    background-color: ${colors.$white};
+
+    .${excutionLogTitle} {
+      margin-bottom: 1rem;
+      font-size: 2rem;
+      font-weight: 500;
+      color: ${colors.$darkNavy};
+    }
+    .${excutionBox} {
+      margin: auto 0;
+      .${log} {
+        margin: 0.1rem 0;
+        font-size: 1rem;
+        line-break: auto;
+      }
+    }
+  `;
+
+  return { excutionLog, excutionLogTitle, excutionBox, log };
+};

--- a/packages/admin/src/components/Manager/ScenarioQueue/index.tsx
+++ b/packages/admin/src/components/Manager/ScenarioQueue/index.tsx
@@ -1,4 +1,4 @@
-import { ScenarioQueueType } from "@shared/types";
+import { ScenarioQueueType } from "src/types";
 import getStyle from "./style";
 
 interface Props {

--- a/packages/admin/src/components/Manager/ScenarioQueue/index.tsx
+++ b/packages/admin/src/components/Manager/ScenarioQueue/index.tsx
@@ -1,0 +1,23 @@
+import { ScenarioQueueType } from "@shared/types";
+import getStyle from "./style";
+
+interface Props {
+  queue: ScenarioQueueType[];
+}
+
+export default function ScenarioQueue({ queue }: Props) {
+  const style = getStyle();
+
+  return (
+    <article className={style.scenarioQueue}>
+      <h2 className={style.scenarioQueueTitle}>시나리오 큐</h2>
+      <div className={style.queue}>
+        {queue.map(({ turn, title }) => (
+          <p key={turn + title} className={style[`${turn}`]}>
+            {title}
+          </p>
+        ))}
+      </div>
+    </article>
+  );
+}

--- a/packages/admin/src/components/Manager/ScenarioQueue/style.ts
+++ b/packages/admin/src/components/Manager/ScenarioQueue/style.ts
@@ -17,7 +17,7 @@ export default () => {
     position: relative;
     width: 32rem;
     min-height: 16rem;
-    margin: 0 0 2rem 2rem;
+    margin: 0 7rem 2rem 0;
     padding: 1.5rem;
     box-shadow: rgba(17, 17, 26, 0.05) 0px 1px 0px,
       rgba(17, 17, 26, 0.1) 0px 0px 8px;
@@ -33,11 +33,10 @@ export default () => {
       margin: auto 0;
       text-align: center;
       .${prev}, .${next} {
-        margin-top: 1.3rem;
         font-size: 1.3rem;
         color: ${colors.$gray.$400};
-        &:first-child {
-          margin-top: 0;
+        &:not(:first-child) {
+          margin-top: 1.3rem;
         }
       }
       .${current} {

--- a/packages/admin/src/components/Manager/ScenarioQueue/style.ts
+++ b/packages/admin/src/components/Manager/ScenarioQueue/style.ts
@@ -1,0 +1,58 @@
+import { css } from "@emotion/css";
+import { colors } from "@shared/styles/color";
+import { hashClassNames } from "src/lib/hash";
+
+export default () => {
+  const { scenarioQueueTitle, queue, prev, next, current } = hashClassNames([
+    "scenarioQueueTitle",
+    "queue",
+    "prev",
+    "next",
+    "current",
+  ]);
+
+  const scenarioQueue = css`
+    display: flex;
+    flex-direction: column;
+    position: relative;
+    width: 32rem;
+    min-height: 16rem;
+    margin: 0 0 2rem 2rem;
+    padding: 1.5rem;
+    box-shadow: rgba(17, 17, 26, 0.05) 0px 1px 0px,
+      rgba(17, 17, 26, 0.1) 0px 0px 8px;
+    border-radius: 1rem;
+    background-color: ${colors.$white};
+
+    .${scenarioQueueTitle} {
+      font-size: 2rem;
+      font-weight: 500;
+      color: ${colors.$darkNavy};
+    }
+    .${queue} {
+      margin: auto 0;
+      text-align: center;
+      .${prev}, .${next} {
+        margin-top: 1.3rem;
+        font-size: 1.3rem;
+        color: ${colors.$gray.$400};
+        &:first-child {
+          margin-top: 0;
+        }
+      }
+      .${current} {
+        margin-top: 1.3rem;
+        font-size: 2rem;
+      }
+    }
+  `;
+
+  return {
+    scenarioQueue,
+    scenarioQueueTitle,
+    queue,
+    prev,
+    next,
+    current,
+  };
+};

--- a/packages/admin/src/components/Manager/ScraperManager/index.tsx
+++ b/packages/admin/src/components/Manager/ScraperManager/index.tsx
@@ -1,0 +1,135 @@
+import { useState } from "react";
+import { useRouteMatch } from "react-router-dom";
+import { FaPlay, FaPause, FaStop } from "react-icons/fa";
+import { MdReplay } from "react-icons/md";
+
+import { cx } from "@emotion/css";
+import { ScenarioQueue, ExcutionLog } from "..";
+import Tooltip from "../../Tooltip";
+import {
+  noticeScenarioQueue,
+  studentScenarioQueue,
+  domitoryScenarioQueue,
+  scheduleScenarioQueue,
+} from "../../../__mockData__";
+import getStyle from "./style";
+
+interface matchProps {
+  scraperType: string;
+}
+
+export default function ScraperManager() {
+  const initialState = {
+    isPlay: false,
+    isPause: false,
+    isStop: false,
+    isReplay: false,
+  };
+
+  const [ buttonState, setButtonState ] = useState(initialState);
+  const match = useRouteMatch<matchProps>("/scraper/:scraperType");
+  const scraperType = match?.params.scraperType;
+  const style = getStyle();
+
+  const getMockScenarioQueue = () => {
+    if (scraperType === "notice") return noticeScenarioQueue;
+    if (scraperType === "domitory") return domitoryScenarioQueue;
+    if (scraperType === "student") return studentScenarioQueue;
+
+    return scheduleScenarioQueue;
+  };
+
+  const startScraping = () => {
+    if (!buttonState.isPlay)
+      setButtonState({
+        isPlay: true,
+        isPause: false,
+        isStop: false,
+        isReplay: false,
+      });
+  };
+
+  const pauseScraping = () => {
+    if (!buttonState.isPause)
+      setButtonState({
+        isPlay: false,
+        isPause: true,
+        isStop: false,
+        isReplay: false,
+      });
+  };
+
+  const stopScraping = () => {
+    if (!buttonState.isStop)
+      setButtonState({
+        isPlay: true,
+        isPause: true,
+        isStop: true,
+        isReplay: false,
+      });
+  };
+
+  const restartScraping = () => {
+    if (!buttonState.isReplay)
+      setButtonState({
+        isPlay: true,
+        isPause: false,
+        isStop: false,
+        isReplay: true,
+      });
+  };
+
+  return (
+    <section className={style.manager}>
+      <article className={style.managerHeader}>
+        <h2 className={style.managerTitle}>스크래퍼 관리</h2>
+        <div className={style.buttonBox}>
+          <button type="button" className={style.button}>
+            <FaPlay
+              className={cx(style.play, {
+                [style.disabled]: buttonState.isPlay,
+              })}
+              onClick={startScraping}
+            />
+            {/* <span className={style.tooltip}>스크래핑 시작</span> */}
+            <Tooltip content="스크래핑 시작" parent={style.button} />
+          </button>
+
+          <button type="button" className={style.button}>
+            <FaPause
+              className={cx(style.pause, {
+                [style.disabled]: buttonState.isPause,
+              })}
+              onClick={pauseScraping}
+            />
+            <span className={style.tooltip}>스크래핑 일시정지</span>
+          </button>
+
+          <button type="button" className={style.button}>
+            <FaStop
+              className={cx(style.stop, {
+                [style.disabled]: buttonState.isStop,
+              })}
+              onClick={stopScraping}
+            />
+            <span className={style.tooltip}>스크래핑 정지</span>
+          </button>
+
+          <button type="button" className={style.button}>
+            <MdReplay
+              className={cx(style.replay, {
+                [style.disabled]: buttonState.isReplay,
+              })}
+              onClick={restartScraping}
+            />
+            <span className={style.tooltip}>스크래핑 다시시작</span>
+          </button>
+        </div>
+      </article>
+      <article className={style.managerBox}>
+        <ScenarioQueue queue={getMockScenarioQueue().queue} />
+        <ExcutionLog log={getMockScenarioQueue().log} />
+      </article>
+    </section>
+  );
+}

--- a/packages/admin/src/components/Manager/ScraperManager/index.tsx
+++ b/packages/admin/src/components/Manager/ScraperManager/index.tsx
@@ -4,14 +4,14 @@ import { FaPlay, FaPause, FaStop } from "react-icons/fa";
 import { MdReplay } from "react-icons/md";
 
 import { cx } from "@emotion/css";
-import { ScenarioQueue, ExcutionLog } from "..";
-import Tooltip from "../../Tooltip";
 import {
   noticeScenarioQueue,
   studentScenarioQueue,
   domitoryScenarioQueue,
   scheduleScenarioQueue,
-} from "../../../__mockData__";
+} from "src/__mockData__";
+import { ScenarioQueue, ExcutionLog } from "..";
+import Tooltip from "../../Tooltip";
 import getStyle from "./style";
 
 interface matchProps {
@@ -19,14 +19,7 @@ interface matchProps {
 }
 
 export default function ScraperManager() {
-  const initialState = {
-    isPlay: false,
-    isPause: false,
-    isStop: false,
-    isReplay: false,
-  };
-
-  const [ buttonState, setButtonState ] = useState(initialState);
+  const [ scraperState, setScraperState ] = useState("");
   const match = useRouteMatch<matchProps>("/scraper/:scraperType");
   const scraperType = match?.params.scraperType;
   const style = getStyle();
@@ -40,43 +33,27 @@ export default function ScraperManager() {
   };
 
   const startScraping = () => {
-    if (!buttonState.isPlay)
-      setButtonState({
-        isPlay: true,
-        isPause: false,
-        isStop: false,
-        isReplay: false,
-      });
+    if (
+      !(
+        scraperState === "start" ||
+        scraperState === "stop" ||
+        scraperState === "restart"
+      )
+    )
+      setScraperState("start");
   };
 
   const pauseScraping = () => {
-    if (!buttonState.isPause)
-      setButtonState({
-        isPlay: false,
-        isPause: true,
-        isStop: false,
-        isReplay: false,
-      });
+    if (!(scraperState === "pause" || scraperState === "stop"))
+      setScraperState("pause");
   };
 
   const stopScraping = () => {
-    if (!buttonState.isStop)
-      setButtonState({
-        isPlay: true,
-        isPause: true,
-        isStop: true,
-        isReplay: false,
-      });
+    if (scraperState !== "stop") setScraperState("stop");
   };
 
   const restartScraping = () => {
-    if (!buttonState.isReplay)
-      setButtonState({
-        isPlay: true,
-        isPause: false,
-        isStop: false,
-        isReplay: true,
-      });
+    if (scraperState !== "restart") setScraperState("restart");
   };
 
   return (
@@ -87,7 +64,10 @@ export default function ScraperManager() {
           <button type="button" className={style.button}>
             <FaPlay
               className={cx(style.play, {
-                [style.disabled]: buttonState.isPlay,
+                [style.disabled]:
+                  scraperState === "start" ||
+                  scraperState === "stop" ||
+                  scraperState === "restart",
               })}
               onClick={startScraping}
             />
@@ -98,7 +78,8 @@ export default function ScraperManager() {
           <button type="button" className={style.button}>
             <FaPause
               className={cx(style.pause, {
-                [style.disabled]: buttonState.isPause,
+                [style.disabled]:
+                  scraperState === "pause" || scraperState === "stop",
               })}
               onClick={pauseScraping}
             />
@@ -108,7 +89,7 @@ export default function ScraperManager() {
           <button type="button" className={style.button}>
             <FaStop
               className={cx(style.stop, {
-                [style.disabled]: buttonState.isStop,
+                [style.disabled]: scraperState === "stop",
               })}
               onClick={stopScraping}
             />
@@ -118,7 +99,7 @@ export default function ScraperManager() {
           <button type="button" className={style.button}>
             <MdReplay
               className={cx(style.replay, {
-                [style.disabled]: buttonState.isReplay,
+                [style.disabled]: scraperState === "restart",
               })}
               onClick={restartScraping}
             />

--- a/packages/admin/src/components/Manager/ScraperManager/style.ts
+++ b/packages/admin/src/components/Manager/ScraperManager/style.ts
@@ -1,0 +1,124 @@
+import { css } from "@emotion/css";
+import { colors } from "@shared/styles/color";
+import { hashClassNames } from "src/lib/hash";
+
+export default () => {
+  const {
+    managerHeader,
+    managerTitle,
+    buttonBox,
+    button,
+    tooltip,
+    play,
+    pause,
+    stop,
+    replay,
+    disabled,
+    managerBox,
+  } = hashClassNames([
+    "managerHeader",
+    "managerTitle",
+    "buttonBox",
+    "button",
+    "tooltip",
+    "play",
+    "pause",
+    "stop",
+    "disabled",
+    "replay",
+    "managerBox",
+  ]);
+
+  const manager = css`
+    max-width: 84rem;
+    margin: 0 3rem 4.5rem 3rem;
+
+    .${managerHeader} {
+      display: flex;
+      height: 2.3rem;
+      margin: 0 0 5rem 0;
+      .${managerTitle} {
+        height: fit-content;
+        font-size: 2.3rem;
+        font-weight: 400;
+      }
+      .${buttonBox} {
+        margin-left: auto;
+        .${button} {
+          height: 2.3rem;
+          margin-left: 0.5rem;
+          padding: 0;
+          border: none;
+          outline: none;
+          background-color: transparent;
+          font-size: 2.3rem;
+          cursor: pointer;
+          &:first-child {
+            margin-left: 0;
+          }
+          .${tooltip} {
+            visibility: hidden;
+            z-index: 1;
+            position: absolute;
+            /* bottom: 100%;
+            left: 50%; */
+            min-width: 6rem;
+            width: fit-content;
+            padding: 0.5rem;
+            border-radius: 6px;
+            background-color: ${colors.$darkMode};
+            color: ${colors.$white};
+            font-size: 0.8rem;
+            text-align: center;
+          }
+          &:hover .${tooltip} {
+            visibility: visible;
+          }
+
+          .${play} {
+            color: ${colors.$googleGreen};
+          }
+          .${pause} {
+            color: ${colors.$googleYellow};
+          }
+          .${stop} {
+            color: ${colors.$googleRed};
+          }
+          .${replay} {
+            color: ${colors.$lightBlue};
+            transition: transform ease 0.5s;
+            &:hover {
+              transform: rotate(-180deg);
+            }
+          }
+          .${disabled} {
+            color: ${colors.$gray.$400};
+            cursor: not-allowed;
+          }
+        }
+      }
+    }
+    .${managerBox} {
+      display: flex;
+      flex-direction: row;
+      justify-content: left;
+      flex-wrap: wrap;
+      align-items: flex-start;
+    }
+  `;
+
+  return {
+    manager,
+    managerHeader,
+    managerTitle,
+    buttonBox,
+    button,
+    tooltip,
+    play,
+    pause,
+    stop,
+    replay,
+    disabled,
+    managerBox,
+  };
+};

--- a/packages/admin/src/components/Manager/ScraperManager/style.ts
+++ b/packages/admin/src/components/Manager/ScraperManager/style.ts
@@ -31,12 +31,12 @@ export default () => {
 
   const manager = css`
     max-width: 84rem;
-    margin: 0 3rem 4.5rem 3rem;
+    margin: 0 3rem 4.5rem;
 
     .${managerHeader} {
       display: flex;
       height: 2.3rem;
-      margin: 0 0 5rem 0;
+      margin-bottom: 5rem;
       .${managerTitle} {
         height: fit-content;
         font-size: 2.3rem;
@@ -63,7 +63,7 @@ export default () => {
             /* bottom: 100%;
             left: 50%; */
             min-width: 6rem;
-            width: fit-content;
+            /* width: fit-content; */
             padding: 0.5rem;
             border-radius: 6px;
             background-color: ${colors.$darkMode};
@@ -100,10 +100,10 @@ export default () => {
     }
     .${managerBox} {
       display: flex;
-      flex-direction: row;
       justify-content: left;
       flex-wrap: wrap;
       align-items: flex-start;
+      margin: 0 0 2rem 2rem;
     }
   `;
 

--- a/packages/admin/src/components/Manager/index.ts
+++ b/packages/admin/src/components/Manager/index.ts
@@ -1,0 +1,3 @@
+export { default as ScraperManager } from "./ScraperManager";
+export { default as ScenarioQueue } from "./ScenarioQueue";
+export { default as ExcutionLog } from "./ExcutionLog";

--- a/packages/admin/src/components/Scraper/index.tsx
+++ b/packages/admin/src/components/Scraper/index.tsx
@@ -6,6 +6,7 @@ import mockCollegeScheduleScenarios from "src/__mockData__/collegeScheduleScenar
 
 import { ScraperType } from "@shared/types";
 import { getScraperLabel } from "src/lib/scraper";
+import { ScraperManager } from "../Manager";
 import getStyle from "./style";
 
 interface Props {
@@ -29,6 +30,8 @@ export default function Scraper({ scraperType }: Props) {
       <h1 className={style.mainTitle}>
         {getScraperLabel(scraperType)} 스크래퍼 관리보드
       </h1>
+      <ScraperManager />
+      <h2 className={style.scenarioTitle}>시나리오 그룹 리스트</h2>
       <ScenarioFilter isNotice={scraperType === "notice"} />
       <ScenarioGroupList scenarios={getMockScenarios()} />
     </main>

--- a/packages/admin/src/components/Scraper/style.ts
+++ b/packages/admin/src/components/Scraper/style.ts
@@ -1,18 +1,27 @@
 import { css } from "@emotion/css";
+import { colors } from "@shared/styles/color";
 import { hashClassNames } from "src/lib/hash";
 
 export default () => {
-  const { mainTitle } = hashClassNames([ "mainTitle" ]);
+  const { mainTitle, scenarioTitle } = hashClassNames([
+    "mainTitle",
+    "scenarioTitle",
+  ]);
 
   const main = css`
     margin-left: 13rem;
 
     .${mainTitle} {
-      margin: 8rem 0 2rem 3rem;
+      margin: 8rem 0 4rem 3rem;
       font-size: 3rem;
+      font-weight: 400;
+    }
+    .${scenarioTitle} {
+      margin: 0 0 1rem 3rem;
+      font-size: 2.3rem;
       font-weight: 400;
     }
   `;
 
-  return { main, mainTitle };
+  return { main, mainTitle, scenarioTitle };
 };

--- a/packages/admin/src/components/Tooltip/index.tsx
+++ b/packages/admin/src/components/Tooltip/index.tsx
@@ -1,0 +1,14 @@
+import { cx } from "@emotion/css";
+import getStyle from "./style";
+
+interface Props {
+  content: string;
+  parent: string;
+}
+
+export default function ScraperManager({ content, parent }: Props) {
+  const style = getStyle(parent);
+  return (
+    <span className={cx(style.tooltip, style.parentHover)}>{content}</span>
+  );
+}

--- a/packages/admin/src/components/Tooltip/style.ts
+++ b/packages/admin/src/components/Tooltip/style.ts
@@ -1,0 +1,36 @@
+import { css } from "@emotion/css";
+import { colors } from "@shared/styles/color";
+import { hashClassNames } from "src/lib/hash";
+
+export default (parent: string) => {
+  //   const { tooltip } = hashClassNames([ "tooltip" ]);
+
+  const tooltip = css`
+    visibility: hidden;
+    z-index: 1;
+    position: absolute;
+    /* bottom: 100%;
+            left: 50%; */
+    min-width: 6rem;
+    width: fit-content;
+    padding: 0.5rem;
+    border-radius: 6px;
+    background-color: ${colors.$darkMode};
+    color: ${colors.$white};
+    font-size: 0.8rem;
+    text-align: center;
+  `;
+
+  const parentHover = css`
+    .${parent}:hover {
+      .${tooltip} {
+        visibility: visible;
+      }
+    }
+  `;
+
+  return {
+    tooltip,
+    parentHover,
+  };
+};

--- a/packages/admin/src/types/index.ts
+++ b/packages/admin/src/types/index.ts
@@ -1,3 +1,18 @@
 import { ScenarioStateType } from "@shared/types";
 
 export type ScenarioFilterType = "all" | ScenarioStateType;
+
+export type ScenarioTurnType = "prev" | "current" | "next";
+
+export type ScenarioQueueType = {
+  id: number;
+  title: string;
+  turn: ScenarioTurnType;
+};
+
+export type ExcutionLogType = {
+  scraperState: string;
+  scenarioState: string;
+  scenarioResult: string;
+  commands?: string[];
+};

--- a/packages/shared/src/styles/color.ts
+++ b/packages/shared/src/styles/color.ts
@@ -12,6 +12,7 @@ const colors = {
   $googleYellow: "#F3B606",
   $googleGreen: "#31A350",
   $darkNavy: "#091E42",
+  $darkMode: "#292a2d",
 };
 
 export { colors };

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -4,8 +4,6 @@ export type Element = {
 
 export type ScenarioStateType = "clean" | "warning" | "error" | "excluded";
 
-export type ScenarioTurnType = "prev" | "current" | "next";
-
 export type ScenarioType = {
   id: number;
   title: string;
@@ -13,18 +11,6 @@ export type ScenarioType = {
   state: ScenarioStateType;
   group?: string;
   tags: string[];
-};
-
-export type ScenarioQueueType = {
-  id: number;
-  title: string;
-  turn: ScenarioTurnType;
-};
-
-export type ExcutionLogType = {
-  scraper: string;
-  result: string;
-  commands?: string[];
 };
 
 export type ScraperType =

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -4,6 +4,8 @@ export type Element = {
 
 export type ScenarioStateType = "clean" | "warning" | "error" | "excluded";
 
+export type ScenarioTurnType = "prev" | "current" | "next";
+
 export type ScenarioType = {
   id: number;
   title: string;
@@ -11,6 +13,18 @@ export type ScenarioType = {
   state: ScenarioStateType;
   group?: string;
   tags: string[];
+};
+
+export type ScenarioQueueType = {
+  id: number;
+  title: string;
+  turn: ScenarioTurnType;
+};
+
+export type ExcutionLogType = {
+  scraper: string;
+  result: string;
+  commands?: string[];
 };
 
 export type ScraperType =


### PR DESCRIPTION
## 👀 이슈

resolve #76 

## 📌 개요

스크래퍼 관리를 위한 UI 개발입니다.

## 👩‍💻 작업 사항

url에 있는 params를 가져와서 스크래퍼에 따라 다른 데이터를 보여주도록 했습니다.
실행 로그에는 `scraper, result, commands`로 구성하였고 `commands`는 string 배열로 실제 서버에 찍히는 로그 예시를 넣어보았습니다.

버튼으로는 시작, 일시정지, 정지, 다시 시작이 있으며 각 버튼을 누르는 상황에 따라 `disable`하도록 했습니다.
또한, 버튼에 tooltip을 넣어봤는데 컴포넌트로 만들면 좋을 것 같아 컴포넌트로 만들고 있지만 부모 태그가 `hover`일 때, tooltip을 보이도록 하는 것이 생각처럼 잘 되지 않아 먼저 pr를 올리고 수정할 예정입니다!

제가 UI/UX가 너무 부족해서.. 수니툰이 멋지게 만들어주셨는데 누가 될 것 같아 걱정입니다ㅠㅠ 의견 있으시면 적극 반영하도록 하겠습니다!

생각해보니 [스크래퍼 상태 정책](https://github.com/CMI-OSS/cbnu-alrami/issues/64)을 반영안해서.. 일어나서 작업하도록 하겠습니다!

## ✅ 참고 사항
https://user-images.githubusercontent.com/62797441/148694800-e30757b3-97c1-45ab-b733-810178633a6e.mov

gif로 하면 좋지만 마우스 포인터가 나오질 않아 부득이하게 영상으로 올렸습니다!