### PR TITLE
[scrapers] 청주시 코로나 확진자 수 및 거리두기수칙(운영시간) 스크래퍼 제작

### DIFF
--- a/packages/scraper/src/index.ts
+++ b/packages/scraper/src/index.ts
@@ -3,12 +3,14 @@ import CalendarScraper from "src/scrapers/CalendarScraper";
 import NoticeScraper from "src/scrapers/NoticeScraper";
 import DomitoryScraper from "src/scrapers/DomitoryScraper";
 import CafeteriaScraper from "src/scrapers/CafeteriaScraper";
+import CovidScraper from "./scrapers/CovidScraper";
 
 async function main() {
-  NoticeScraper.start();
-  CalendarScraper.start();
-  DomitoryScraper.start();
-  CafeteriaScraper.start();
+  // NoticeScraper.start();
+  // CalendarScraper.start();
+  // DomitoryScraper.start();
+  // CafeteriaScraper.start();
+  CovidScraper.start();
 }
 
 main();

--- a/packages/scraper/src/index.ts
+++ b/packages/scraper/src/index.ts
@@ -6,10 +6,10 @@ import CafeteriaScraper from "src/scrapers/CafeteriaScraper";
 import CovidScraper from "./scrapers/CovidScraper";
 
 async function main() {
-  // NoticeScraper.start();
-  // CalendarScraper.start();
-  // DomitoryScraper.start();
-  // CafeteriaScraper.start();
+  NoticeScraper.start();
+  CalendarScraper.start();
+  DomitoryScraper.start();
+  CafeteriaScraper.start();
   CovidScraper.start();
 }
 

--- a/packages/scraper/src/scrapers/CovidScraper/index.ts
+++ b/packages/scraper/src/scrapers/CovidScraper/index.ts
@@ -1,0 +1,69 @@
+/* eslint-disable no-plusplus */
+/* eslint-disable no-useless-catch */
+import Scraper from "../Scraper";
+import { Scenario } from "../Scenario";
+
+interface covidDetailInfo {
+  bar: 1;
+  karaoke: 2;
+  gym: 3;
+  restaurantAndCafe: 5;
+  PCRoom: 7;
+}
+
+interface CovidScript {
+  HOMEPAGE_URL: string;
+  DETAIL_PAGE_URL: string;
+  getCovidNumber: () => string;
+  getCovidDetailInfo: () => covidDetailInfo;
+}
+
+class CovidScraper extends Scraper<CovidScript> {
+  constructor() {
+    super(`${__dirname}/scripts`);
+  }
+
+  async start() {
+    const scripts = await this.loadScripts();
+
+    scripts.forEach((script) => {
+      this.appendScenario(new Scenario(script));
+    });
+
+    this.run();
+  }
+
+  async scrapping(script: Scenario<CovidScript>) {
+    try {
+      const { jsScript } = script;
+
+      if (!this.scraper) throw Error("크롤러 없음");
+      if (!jsScript) throw Error("스크립트 없음.");
+
+      await this.scraper.goto(jsScript.HOMEPAGE_URL);
+      await this.evaluateScript(jsScript);
+
+      const covidNumber = await this.scraper.evaluate(
+        `script.getCovidNumber()`,
+      );
+
+      await this.scraper.goto(jsScript.DETAIL_PAGE_URL);
+      await this.evaluateScript(jsScript);
+
+      const covidDetailInfo = await this.scraper.evaluate(
+        "script.getCovidDetailInfo()",
+      );
+
+      if (!covidNumber) throw Error("Error!");
+
+      // eslint-disable-next-line no-console
+      console.log(`청주시 확진자 수: ${covidNumber.slice(0, -1)}`);
+      // eslint-disable-next-line no-console
+      console.log(covidDetailInfo);
+    } catch (error) {
+      throw error;
+    }
+  }
+}
+
+export default new CovidScraper();

--- a/packages/scraper/src/scrapers/CovidScraper/scripts/covid.js
+++ b/packages/scraper/src/scrapers/CovidScraper/scripts/covid.js
@@ -1,0 +1,38 @@
+const script = {
+    HOMEPAGE_URL: "https://corona.cheongju.go.kr/corona.html",
+    DETAIL_PAGE_URL: "https://corona.cheongju.go.kr/common/jsp/covid-19/index.html#tab3",
+
+    getCovidNumber: function () {
+        const covidNumber = document.querySelector("#demo");
+        return covidNumber.textContent;
+    },
+
+    getCovidDetailInfo: function () {
+        const allTables = document.querySelectorAll("table");
+        const targetTable = allTables[2];
+        const tableRows = targetTable.querySelectorAll("tr");
+
+        const tableIndexOfPlaces = {
+            bar: 1,
+            karaoke: 2,
+            gym: 3,
+            restaurantAndCafe: 5,
+            PCRoom: 7,
+        }
+
+        let covidDetailInfo = {};
+
+        Object.entries(tableIndexOfPlaces).forEach(([key, value]) => {
+            const availableTime = tableRows[value]
+                .querySelectorAll("td")[1]
+                .querySelector("ul")
+                .querySelector("li")
+                .textContent;
+            covidDetailInfo[key] = availableTime;
+        });
+
+        return covidDetailInfo;
+    }
+}
+
+module.exports = script;

--- a/packages/scraper/src/scrapers/CovidScraper/scripts/covid.js
+++ b/packages/scraper/src/scrapers/CovidScraper/scripts/covid.js
@@ -8,9 +8,9 @@ const script = {
     },
 
     getCovidDetailInfo: function () {
-        const allTables = document.querySelectorAll("table");
-        const targetTable = allTables[2];
-        const tableRows = targetTable.querySelectorAll("tr");
+        const tableRows = document
+            .querySelectorAll("table")[2]
+            .querySelectorAll("tr");
 
         const tableIndexOfPlaces = {
             bar: 1,
@@ -20,18 +20,19 @@ const script = {
             PCRoom: 7,
         }
 
-        let covidDetailInfo = {};
+        let rawStringInfo = {};
 
         Object.entries(tableIndexOfPlaces).forEach(([key, value]) => {
-            const availableTime = tableRows[value]
+            const rawString = tableRows[value]
                 .querySelectorAll("td")[1]
                 .querySelector("ul")
                 .querySelector("li")
                 .textContent;
-            covidDetailInfo[key] = availableTime;
+            
+            rawStringInfo[key] = rawString;
         });
 
-        return covidDetailInfo;
+        return rawStringInfo;
     }
 }
 


### PR DESCRIPTION
## 👀 이슈

resolve #101 

## 📌 개요

충림이 v2에서 사용할 청주시 코로나 정보 스크래퍼를 제작합니다. 스크래퍼의 데모 버전으로, 스크래핑한 데이터를 콘솔에 출력합니다.

## 👩‍💻 작업 사항

- scrapers 패키지에 `CovidScraper` 디렉토리 추가.
- 청주시 홈페이지에서 확진자 수, 운영시간을 스크래핑 해 올 스크립트 제작.
- 스크립트 삽입 후 스크래핑한 데이터를 콘솔에 출력하는 간단한 스크래퍼 제작.

## ✅ 참고 사항

콘솔 출력 결과입니다.

```
scraper: 청주시 확진자 수: 11428
scraper: {
scraper:   bar: '21시~다음날 05시까지 운영 제한',
scraper:   karaoke: '21시~다음날 05시까지 운영 제한',
scraper:   gym: '21시~다음날 05시까지 운영 제한',
scraper:   restaurantAndCafe: '21시~다음날 05시까지 운영 제한 ※ 포장‧배달 시 방역패스 미적용',
scraper:   PCRoom: '22시~다음날 05시까지 운영 제한'
scraper: }
```
