### PR TITLE
[admin] 관리자 관리 페이지 - 관리자 목록 보기 및 수정 페이지 마크업

### DIFF
--- a/packages/admin/src/App.tsx
+++ b/packages/admin/src/App.tsx
@@ -6,6 +6,7 @@ import useSocket from "src/hooks/useSocket";
 import Navigation from "./components/Navigation";
 import LoginPage from "./pages/Login";
 import BoardPage from "./pages/BoardPage";
+import AdminManagementPage from "./pages/AdminManagementPage";
 import { store } from "./store";
 import "@shared/styles/global.scss";
 import "./admin.scss";
@@ -21,6 +22,7 @@ function App() {
           <Route path="/login" element={<LoginPage />} />
           <Route path="/board/*" element={<BoardPage />} />
           <Route path="/scraper/*" element={<ScraperPage />} />
+          <Route path="/manage/*" element={<AdminManagementPage />} />
           <Route path="*" element={<Navigate to="/scraper/notice" />} />
         </Routes>
       </BrowserRouter>

--- a/packages/admin/src/__mockData__/admins.ts
+++ b/packages/admin/src/__mockData__/admins.ts
@@ -1,0 +1,69 @@
+export enum Authorities {
+  Super = 0,
+  Council = 1,
+}
+
+const admins = [
+  {
+    id: 0,
+    name: "수니",
+    authority: Authorities.Super,
+    createdDate: "2020-01-12",
+    boards: [
+      "심리학과 학생회 공지",
+      "총학생회 공지",
+      "소프트웨어학과 학생회 공지",
+    ],
+  },
+  {
+    id: 1,
+    name: "브루니",
+    authority: Authorities.Super,
+    createdDate: "2020-04-12",
+    boards: [ "소프트웨어학과 학생회 공지" ],
+  },
+  {
+    id: 2,
+    name: "총학생회 멤버1",
+    authority: Authorities.Council,
+    createdDate: "2020-01-12",
+    boards: [ "총학생회 공지" ],
+  },
+  {
+    id: 3,
+    name: "총학생회 멤버1",
+    authority: Authorities.Council,
+    createdDate: "2020-01-12",
+    boards: [ "총학생회 공지" ],
+  },
+  {
+    id: 4,
+    name: "총학생회 멤버1",
+    authority: Authorities.Council,
+    createdDate: "2020-01-12",
+    boards: [ "총학생회 공지" ],
+  },
+  {
+    id: 5,
+    name: "총학생회 멤버1",
+    authority: Authorities.Council,
+    createdDate: "2020-01-12",
+    boards: [ "총학생회 공지" ],
+  },
+  {
+    id: 6,
+    name: "총학생회 멤버1",
+    authority: Authorities.Council,
+    createdDate: "2020-01-12",
+    boards: [ "총학생회 공지" ],
+  },
+  {
+    id: 7,
+    name: "총학생회 멤버1",
+    authority: Authorities.Council,
+    createdDate: "2020-01-12",
+    boards: [ "총학생회 공지" ],
+  },
+];
+
+export default admins;

--- a/packages/admin/src/__mockData__/index.ts
+++ b/packages/admin/src/__mockData__/index.ts
@@ -10,6 +10,8 @@ import scheduleScenarioQueue from "./collegeScheduleScenarioQueue";
 
 import boardCategories from "./boardCategories";
 
+import admins from "./admins";
+
 export {
   noticeScenariosMockData,
   studentRestaurantScenariosMockData,
@@ -20,4 +22,5 @@ export {
   noticeScenarioQueue,
   studentScenarioQueue,
   boardCategories,
+  admins,
 };

--- a/packages/admin/src/components/AdminManagement/AdminCard/index.tsx
+++ b/packages/admin/src/components/AdminManagement/AdminCard/index.tsx
@@ -1,0 +1,196 @@
+import { ChangeEvent, Dispatch, SetStateAction, useState } from "react";
+import classNames from "classnames";
+import { BsArrowBarDown, BsArrowBarUp } from "react-icons/bs";
+import { Authorities } from "src/__mockData__/admins";
+import SelectedBoard from "../SelectedBoard";
+import $ from "./style.module.scss";
+
+export type Admin = {
+  id: number;
+  name: string;
+  authority: Authorities;
+  createdDate: string;
+  boards: Array<string>;
+};
+
+type Props = {
+  admin: Admin;
+  onAdminChange: Dispatch<SetStateAction<Array<Admin>>>;
+  className: string;
+};
+
+const AUTHORITY_OPTIONS = [ "super", "council" ];
+const BOARDS = [
+  "심리학과 학생회 공지",
+  "소프트웨어학과 학생회 공지",
+  "경영대학 학생회 공지",
+  "총학생회 공지",
+  "CMI 공지",
+];
+
+export default function AdminCard({
+  admin: { id, authority, boards, name, createdDate },
+  onAdminChange,
+  className,
+}: Props) {
+  const [ isDetailHidden, setIsDetailHidden ] = useState(true);
+  const [ preSelectedBoard, setPreSelectedBoard ] = useState("");
+  const [ isHiddenConfirmButton, setIsHiddenConfirmButton ] = useState(true);
+
+  function onAutorityChange(event: ChangeEvent<HTMLSelectElement>) {
+    const {
+      target: { value },
+    } = event;
+
+    onAdminChange((pre) =>
+      pre.map((admin) => {
+        if (admin.id === id)
+          return { ...admin, authority: parseInt(value, 10) };
+        return admin;
+      }),
+    );
+  }
+
+  function addBoard(event: ChangeEvent<HTMLSelectElement>) {
+    const {
+      target: { value },
+    } = event;
+
+    onAdminChange((pre) =>
+      pre.map((admin) => {
+        if (admin.id === id) {
+          const { boards } = admin;
+          if (boards.includes(value)) {
+            setPreSelectedBoard(value);
+            setTimeout(() => setPreSelectedBoard(""), 500);
+            return admin;
+          }
+          boards.push(value);
+          return { ...admin, boards };
+        }
+        return admin;
+      }),
+    );
+  }
+
+  function deleteAdmin() {
+    onAdminChange((pre) => pre.filter((admin) => admin.id !== id));
+  }
+
+  return (
+    <li className={classNames($.container, className)}>
+      <div className={$["admin-preview"]}>
+        <div className={$.cell}>
+          <span>#{id}</span>
+        </div>
+        <div className={$.cell}>
+          <span>{name}</span>
+        </div>
+        <div className={$.cell}>
+          <span
+            className={authority === Authorities.Super ? $["super-user"] : ""}
+          >
+            {authority === Authorities.Super ? "super" : "council"}
+          </span>
+        </div>
+        <div className={$.cell}>
+          <span>{createdDate}</span>
+        </div>
+        <button
+          type="button"
+          className={$["show-detail-button"]}
+          onClick={() => setIsDetailHidden((pre) => !pre)}
+        >
+          {isDetailHidden ? <BsArrowBarDown /> : <BsArrowBarUp />}
+        </button>
+      </div>
+      <div
+        className={classNames(
+          $["admin-hidden-container"],
+          isDetailHidden ? $.hidden : "",
+        )}
+      >
+        <hr className={$["split-line"]} />
+        <h2 className={$["editor-title"]}>권한 수정</h2>
+        <label htmlFor="authority-selector" className={className}>
+          권한
+          <select
+            className={$.selector}
+            id="authority-selector"
+            value={authority}
+            onChange={onAutorityChange}
+          >
+            {AUTHORITY_OPTIONS.map((option, index) => (
+              <option key={option} value={index}>
+                {option}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label htmlFor="board-selector" className={className}>
+          관리 보드 추가
+          <select
+            className={$.selector}
+            id="board-selector"
+            value="선택"
+            onChange={addBoard}
+          >
+            {[ "선택", ...BOARDS ].map((option) => (
+              <option key={option} value={option}>
+                {option}
+              </option>
+            ))}
+          </select>
+        </label>
+        <h2 className={$["editor-title"]}>관리중인 보드</h2>
+        <ul className={$["selected-board-container"]}>
+          {boards.map((board) => (
+            <SelectedBoard
+              key={board}
+              id={id}
+              title={board}
+              className={classNames(
+                $["selected-board"],
+                preSelectedBoard === board ? $.alert : "",
+              )}
+              onAdminChange={onAdminChange}
+            />
+          ))}
+        </ul>
+        <h2 className={$["editor-title"]}>위험한 설정</h2>
+        {isHiddenConfirmButton ? (
+          <button
+            className={classNames($["delete-admin-button"], $["delete-button"])}
+            type="button"
+            onClick={() => setIsHiddenConfirmButton((pre) => !pre)}
+          >
+            관리자 삭제
+          </button>
+        ) : (
+          <>
+            <button
+              className={classNames(
+                $["delete-confirm-button"],
+                $["delete-button"],
+              )}
+              type="button"
+              onClick={deleteAdmin}
+            >
+              정말로 삭제하시겠습니까?
+            </button>
+            <button
+              type="button"
+              className={classNames(
+                $["delete-button"],
+                $["cancel-delete-button"],
+              )}
+              onClick={() => setIsHiddenConfirmButton((pre) => !pre)}
+            >
+              취소
+            </button>
+          </>
+        )}
+      </div>
+    </li>
+  );
+}

--- a/packages/admin/src/components/AdminManagement/AdminCard/style.module.scss
+++ b/packages/admin/src/components/AdminManagement/AdminCard/style.module.scss
@@ -1,0 +1,98 @@
+@import "@shared/styles/color.scss";
+
+.container {
+    padding: 1.5rem;
+    background-color: $white;
+    border-radius: 1rem;
+    box-shadow: rgba(17, 17, 26, 0.05) 0px 1px 0px, rgba(17, 17, 26, 0.1) 0px 0px 8px;
+
+    &:hover {
+        box-shadow: 0 0 0 0.1rem $blue-200;
+    }
+
+    .admin-preview {
+        display: flex;
+
+        .cell {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: 20%;
+
+            .super-user {
+                font-weight: 600;
+                color: $google-yellow;
+            }
+        }
+
+        .show-detail-button {
+            width: 20%;
+            background-color: transparent;
+        }
+    }
+
+    .admin-hidden-container {
+        .split-line {
+            margin: 1rem 0;
+            border: none;
+            border-bottom: 0.1rem solid $blue-200;
+        }
+
+        .selector {
+            margin: 0 2rem 0 1rem;
+            padding: 0.5rem;
+            border: none;
+            border-radius: 0.4rem;
+            box-shadow: rgba(0, 0, 0, 0.1) 0px 1px 3px 0px, rgba(0, 0, 0, 0.06) 0px 1px 2px 0px;
+
+            &:hover {
+                box-shadow: 0 0 0 0.1rem $blue-200;
+            }
+        }
+
+        .editor-title {
+            margin: 1.5rem 0;
+            font-size: 1.05rem;
+            font-weight: 500;
+        }
+
+        .selected-board-container {
+            display: flex;
+            flex-wrap: wrap;
+
+            .selected-board {
+                margin-right: 1rem;
+            }
+
+            .alert {
+                background-color: $google-red;
+            }
+        }
+
+        .delete-button {
+            padding: 0.2rem 2rem;
+            border-radius: 0.8rem;
+            box-shadow: rgba(0, 0, 0, 0.1) 0px 1px 3px 0px, rgba(0, 0, 0, 0.06) 0px 1px 2px 0px;
+        }
+
+        .delete-admin-button {
+            box-shadow: 0 0 0 0.1rem $google-red;
+            color: $google-red;
+            background-color: $white;
+        }
+
+        .delete-confirm-button {
+            color: $white;
+            background-color: $google-red;
+        }
+
+        .cancel-delete-button {
+            margin-left: 1rem;
+            background-color: $gray-300;
+        }
+    }
+}
+
+.hidden {
+    display: none;
+}

--- a/packages/admin/src/components/AdminManagement/AdminCard/style.module.scss
+++ b/packages/admin/src/components/AdminManagement/AdminCard/style.module.scss
@@ -39,7 +39,7 @@
         }
 
         .selector {
-            margin: 0 2rem 0 1rem;
+            margin: 1.5rem 2rem 0 1rem;
             padding: 0.5rem;
             border: none;
             border-radius: 0.4rem;
@@ -51,12 +51,13 @@
         }
 
         .editor-title {
-            margin: 1.5rem 0;
+            margin-top: 1.5rem;
             font-size: 1.05rem;
             font-weight: 500;
         }
 
         .selected-board-container {
+            margin-top: 1.5rem;
             display: flex;
             flex-wrap: wrap;
 
@@ -70,6 +71,7 @@
         }
 
         .delete-button {
+            margin-top: 1.5rem;
             padding: 0.2rem 2rem;
             border-radius: 0.8rem;
             box-shadow: rgba(0, 0, 0, 0.1) 0px 1px 3px 0px, rgba(0, 0, 0, 0.06) 0px 1px 2px 0px;

--- a/packages/admin/src/components/AdminManagement/AdminList/index.tsx
+++ b/packages/admin/src/components/AdminManagement/AdminList/index.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { admins } from "src/__mockData__";
+import { Authorities } from "src/__mockData__/admins";
 import AdminCard from "../AdminCard";
 import $ from "./style.module.scss";
 
@@ -8,11 +9,57 @@ const TABLE_HEADS = [ "ID", "닉네임", "권한", "생성일", "상세 설정 �
 export default function AdminList() {
   const [ adminData, setAdminData ] = useState(admins);
 
+  const changeAuthority = (id: number, authority: Authorities) => {
+    setAdminData((pre) =>
+      pre.map((admin) => {
+        if (admin.id === id) return { ...admin, authority };
+        return admin;
+      }),
+    );
+  };
+
+  const deleteAdmin = (id: number) =>
+    setAdminData((pre) => pre.filter((admin) => admin.id !== id));
+
+  const searchBoard = (id: number, board: string) => {
+    const admin = adminData.find((admin) => admin.id === id);
+    if (!admin) return false;
+    const isExist = admin.boards.includes(board);
+    return isExist;
+  };
+
+  const addBoard = (id: number, board: string) => {
+    setAdminData((pre) =>
+      pre.map((admin) => {
+        if (admin.id === id) {
+          const { boards } = admin;
+          if (boards.includes(board)) return admin;
+          boards.push(board);
+          return { ...admin, boards };
+        }
+        return admin;
+      }),
+    );
+  };
+
+  const deleteBoard = (id: number, board: string) => {
+    setAdminData((pre) =>
+      pre.map((admin) => {
+        if (admin.id === id) {
+          const { boards } = admin;
+          const newBoards = boards.filter((item) => item !== board);
+          return { ...admin, boards: newBoards };
+        }
+        return admin;
+      }),
+    );
+  };
+
   return (
     <div className={$.container}>
       <h1 className={$["main-title"]}>관리자 목록</h1>
       <h2 className={$["sub-title"]}>
-        {adminData.length}명의 관리자가 있습니다.
+        <em>{adminData.length}</em>명의 관리자가 있습니다.
       </h2>
       <ul>
         <li className={$["column-titles"]}>
@@ -28,8 +75,12 @@ export default function AdminList() {
           <AdminCard
             key={admin.id}
             admin={admin}
-            onAdminChange={setAdminData}
+            changeAuthority={changeAuthority}
+            deleteAdmin={deleteAdmin}
             className={$.card}
+            addBoard={addBoard}
+            searchBoard={searchBoard}
+            deleteBoard={deleteBoard}
           />
         ))}
       </ul>

--- a/packages/admin/src/components/AdminManagement/AdminList/index.tsx
+++ b/packages/admin/src/components/AdminManagement/AdminList/index.tsx
@@ -1,0 +1,38 @@
+import { useState } from "react";
+import { admins } from "src/__mockData__";
+import AdminCard from "../AdminCard";
+import $ from "./style.module.scss";
+
+const TABLE_HEADS = [ "ID", "닉네임", "권한", "생성일", "상세 설정 보기" ];
+
+export default function AdminList() {
+  const [ adminData, setAdminData ] = useState(admins);
+
+  return (
+    <div className={$.container}>
+      <h1 className={$["main-title"]}>관리자 목록</h1>
+      <h2 className={$["sub-title"]}>
+        {adminData.length}명의 관리자가 있습니다.
+      </h2>
+      <ul>
+        <li className={$["column-titles"]}>
+          {TABLE_HEADS.map((title) => (
+            <span key={title} className={$.title}>
+              {title}
+            </span>
+          ))}
+        </li>
+      </ul>
+      <ul>
+        {adminData.map((admin) => (
+          <AdminCard
+            key={admin.id}
+            admin={admin}
+            onAdminChange={setAdminData}
+            className={$.card}
+          />
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/packages/admin/src/components/AdminManagement/AdminList/style.module.scss
+++ b/packages/admin/src/components/AdminManagement/AdminList/style.module.scss
@@ -1,0 +1,32 @@
+.container {
+    margin: 3rem 3rem 0 15rem;
+    padding-bottom: 3rem;
+    width: 65%;
+
+    .main-title {
+        font-size: 2rem;
+        font-weight: 500;
+    }
+
+    .sub-title {
+        margin-top: 1rem;
+        font-size: 1.1rem;
+    }
+
+    .column-titles {
+        display: flex;
+        margin-top: 2rem;
+        padding: 1.5rem;
+        font-weight: 600;
+
+        .title {
+            display: block;
+            width: 20%;
+            text-align: center;
+        }
+    }
+
+    .card {
+        margin-bottom: 0.5rem;
+    }
+}

--- a/packages/admin/src/components/AdminManagement/NewAdmin/index.tsx
+++ b/packages/admin/src/components/AdminManagement/NewAdmin/index.tsx
@@ -1,0 +1,5 @@
+import $ from "./style.module.scss";
+
+export default function NewAdmin() {
+  return <div style={{ marginLeft: "13rem" }}>Hello</div>;
+}

--- a/packages/admin/src/components/AdminManagement/SelectedBoard/index.tsx
+++ b/packages/admin/src/components/AdminManagement/SelectedBoard/index.tsx
@@ -1,42 +1,28 @@
 import classNames from "classnames";
-import { Dispatch, SetStateAction } from "react";
 import { MdCancel } from "react-icons/md";
-import { Admin } from "../AdminCard";
 import $ from "./style.module.scss";
 
 type Props = {
   id: number;
   title: string;
   className: string;
-  onAdminChange: Dispatch<SetStateAction<Array<Admin>>>;
+  deleteBoard: (id: number, board: string) => void;
 };
 
 export default function SelectedBoard({
   id,
   title,
   className,
-  onAdminChange,
+  deleteBoard,
 }: Props) {
-  function deleteBoard() {
-    onAdminChange((pre) =>
-      pre.map((admin) => {
-        if (admin.id === id) {
-          const { boards } = admin;
-          const newBoards = boards.filter((board) => board !== title);
-          return { ...admin, boards: newBoards };
-        }
-        return admin;
-      }),
-    );
-  }
-
   return (
     <li className={classNames($.container, className)}>
       <span>{title}</span>
       <button
         className={$["delete-button"]}
         type="button"
-        onClick={deleteBoard}
+        onClick={() => deleteBoard(id, title)}
+        aria-label="보드 관리 권한 없애기"
       >
         <MdCancel />
       </button>

--- a/packages/admin/src/components/AdminManagement/SelectedBoard/index.tsx
+++ b/packages/admin/src/components/AdminManagement/SelectedBoard/index.tsx
@@ -1,0 +1,45 @@
+import classNames from "classnames";
+import { Dispatch, SetStateAction } from "react";
+import { MdCancel } from "react-icons/md";
+import { Admin } from "../AdminCard";
+import $ from "./style.module.scss";
+
+type Props = {
+  id: number;
+  title: string;
+  className: string;
+  onAdminChange: Dispatch<SetStateAction<Array<Admin>>>;
+};
+
+export default function SelectedBoard({
+  id,
+  title,
+  className,
+  onAdminChange,
+}: Props) {
+  function deleteBoard() {
+    onAdminChange((pre) =>
+      pre.map((admin) => {
+        if (admin.id === id) {
+          const { boards } = admin;
+          const newBoards = boards.filter((board) => board !== title);
+          return { ...admin, boards: newBoards };
+        }
+        return admin;
+      }),
+    );
+  }
+
+  return (
+    <li className={classNames($.container, className)}>
+      <span>{title}</span>
+      <button
+        className={$["delete-button"]}
+        type="button"
+        onClick={deleteBoard}
+      >
+        <MdCancel />
+      </button>
+    </li>
+  );
+}

--- a/packages/admin/src/components/AdminManagement/SelectedBoard/style.module.scss
+++ b/packages/admin/src/components/AdminManagement/SelectedBoard/style.module.scss
@@ -1,0 +1,27 @@
+@import "@shared/styles/color.scss";
+
+.container {
+    display: flex;
+    align-items: center;
+    margin-top: 0.5rem;
+    padding: 0.1rem 0.5rem;
+    border-radius: 0.5rem;
+    color: $white;
+    background-color: $blue-200;
+    font-size: 0.8rem;
+    box-shadow: rgba(0, 0, 0, 0.1) 0px 1px 3px 0px, rgba(0, 0, 0, 0.06) 0px 1px 2px 0px;
+
+    .delete-button {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        margin-left: 0.4rem;
+        font-size: 1rem;
+        color: $white;
+        background-color: transparent;
+
+        &:hover {
+            color: $gray-400;
+        }
+    }
+}

--- a/packages/admin/src/components/AdminManagement/index.ts
+++ b/packages/admin/src/components/AdminManagement/index.ts
@@ -1,0 +1,4 @@
+import NewAdmin from "./NewAdmin";
+import AdminList from "./AdminList";
+
+export { NewAdmin, AdminList };

--- a/packages/admin/src/components/Navigation/index.tsx
+++ b/packages/admin/src/components/Navigation/index.tsx
@@ -38,13 +38,26 @@ const BOARD_MENUS = {
     },
   ],
 };
+const ADMIN_MANAGE_MENUS = {
+  label: "관리자 관리",
+  menus: [
+    {
+      path: "/manage/add",
+      label: "관리자 추가",
+    },
+    {
+      path: "/manage/list",
+      label: "관리자 목록",
+    },
+  ],
+};
 
 export default function Navigation() {
   const isLoginMatch = useMatch("/login");
   const { pathname } = useLocation();
   const [ active, setActive ] = useState(-1);
   const boardState = useAppSelector((state) => state.boardReducer.board.write);
-  const navMenus = [ BOARD_MENUS, SCRAPER_MENUS ];
+  const navMenus = [ BOARD_MENUS, SCRAPER_MENUS, ADMIN_MANAGE_MENUS ];
 
   useEffect(() => {
     navMenus.forEach(({ menus }, idx) => {

--- a/packages/admin/src/pages/AdminManagementPage/index.tsx
+++ b/packages/admin/src/pages/AdminManagementPage/index.tsx
@@ -1,0 +1,11 @@
+import { Routes, Route } from "react-router-dom";
+import { AdminList, NewAdmin } from "src/components/AdminManagement";
+
+export default function AdminManagementPage() {
+  return (
+    <Routes>
+      <Route path="/add" element={<NewAdmin />} />
+      <Route path="/list" element={<AdminList />} />
+    </Routes>
+  );
+}


### PR DESCRIPTION
## 👀 이슈

resolve #161

## 📌 개요

관리자를 관리하는 페이지를 제작합니다. 이슈를 크게 관리자 추가 페이지와 관리자 목록 페이지로 나눴습니다. 디자인 및 마크업을 진행하였으며 목데이터를 활용하여 동작 데모를 구현하였습니다.

## 👩‍💻 작업 사항

- [x] 리액트 라우터에 `/manage` 경로 추가.
- [x] 네비게이션에 관리자 관리 메뉴 추가.
- [x] 관리자 목록 페이지 마크업.
- [x] 관리자 정보 수정 및 삭제 기능 데모로 구현.

## ✅ 참고 사항

<img width="1392" alt="스크린샷 2022-04-10 오전 4 17 03" src="https://user-images.githubusercontent.com/71015915/162588845-1df16946-3cc2-4a35-8e1e-b6891f52cf7d.png">
<img width="1392" alt="스크린샷 2022-04-10 오전 4 17 09" src="https://user-images.githubusercontent.com/71015915/162588850-2ecbb807-4061-44ac-bbfd-48a3626a44d6.png">

30초 이상의 GIF 파일이 재생되지 않아서 [유튜브 링크](https://youtu.be/a6tL56FeV2A)로 대체합니다.


