### PR TITLE
[mobile] flicking -> css 전환

### DIFF
--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -15,7 +15,6 @@
     "react-router-dom": "^6.2.2"
   },
   "devDependencies": {
-    "@egjs/react-flicking": "^4.5.3",
     "@types/navermaps": "^3.0.13",
     "classnames": "^2.3.1",
     "file-loader": "^6.2.0",

--- a/packages/mobile/src/components/molecules/MenuButtonList/index.tsx
+++ b/packages/mobile/src/components/molecules/MenuButtonList/index.tsx
@@ -1,5 +1,4 @@
 import MenuButton from "@components/atoms/MenuButton";
-import Flicking from "@egjs/react-flicking";
 
 import $ from "./style.module.scss";
 
@@ -7,23 +6,15 @@ function MenuButtonList() {
   const items = [ "학교", "음식점" ];
 
   return (
-    <Flicking
-      className={$.flicking}
-      moveType="freeScroll"
-      bound
-      align="prev"
-      horizontal
-    >
-      <div className={$.wrap}>
-        {items.map((item, index) => (
-          <MenuButton
-            // eslint-disable-next-line react/no-array-index-key
-            key={`button-${index}`}
-            menuButtonItem={item}
-          ></MenuButton>
-        ))}
-      </div>
-    </Flicking>
+    <div className={$.wrap}>
+      {items.map((item, index) => (
+        <MenuButton
+          // eslint-disable-next-line react/no-array-index-key
+          key={`button-${index}`}
+          menuButtonItem={item}
+        ></MenuButton>
+      ))}
+    </div>
   );
 }
 

--- a/packages/mobile/src/components/molecules/MenuButtonList/style.module.scss
+++ b/packages/mobile/src/components/molecules/MenuButtonList/style.module.scss
@@ -1,10 +1,7 @@
-.flicking {
+.wrap {
+  display: flex;
   position: fixed;
   top: 11px;
   left: 30px;
   z-index: 100;
-}
-
-.wrap {
-  display: flex;
 }

--- a/packages/mobile/src/page/Category/index.tsx
+++ b/packages/mobile/src/page/Category/index.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { NavLink } from "react-router-dom";
 
-import Flicking from "@egjs/react-flicking";
 import { MapArrow } from "src/components/atoms/icon/MapArrow";
 
 import $ from "./style.module.scss";
@@ -67,29 +66,21 @@ function Category() {
         </button>
       </div>
       <div className={$.menu}>
-        <Flicking
-          className={$.flicking}
-          moveType="freeScroll"
-          bound
-          align="prev"
-          horizontal
-        >
-          <div className={$.list}>
-            {menuList.map((item, idx) => {
-              return (
-                <NavLink
-                  key={`menu-${item.id}`}
-                  to={item.path}
-                  className={$.menu_link}
-                  onClick={() => setMenu(idx)}
-                  aria-selected={menu === idx + 1}
-                >
-                  {item.name}
-                </NavLink>
-              );
-            })}
-          </div>
-        </Flicking>
+        <div className={$.list}>
+          {menuList.map((item, idx) => {
+            return (
+              <NavLink
+                key={`menu-${item.id}`}
+                to={item.path}
+                className={$.menu_link}
+                onClick={() => setMenu(idx)}
+                aria-selected={menu === idx + 1}
+              >
+                {item.name}
+              </NavLink>
+            );
+          })}
+        </div>
       </div>
       <div className={$.content}>
         <div className={$.hash}>

--- a/packages/mobile/src/page/Category/style.module.scss
+++ b/packages/mobile/src/page/Category/style.module.scss
@@ -1,5 +1,6 @@
 @import "@shared/styles/color.scss";
 @import "@shared/styles/variables.scss";
+@import "@shared/styles/mixin.scss";
 
 @mixin hover-status($color, $decoration) {
   color: $color;
@@ -54,6 +55,8 @@
 
 .list {
   display: flex;
+
+  @include flicking;
 }
 
 .menu_link {
@@ -61,6 +64,7 @@
   font-size: 14px;
   line-height: 18px;
   padding: 8px;
+  white-space: nowrap;
   color: $black-80;
 
   &:not(:first-child) {
@@ -99,6 +103,8 @@
   background-color: $white;
   border-top: 3px solid $background;
   box-shadow: $border-box-shadow;
+
+  @include flicking;
 }
 
 .hash_link {
@@ -106,6 +112,7 @@
   font-size: 14px;
   line-height: 18px;
   padding: 7px 8px 7px 10px;
+  white-space: nowrap;
 
   &:not(:first-child) {
     margin-left: 12px;

--- a/packages/shared/src/styles/mixin.scss
+++ b/packages/shared/src/styles/mixin.scss
@@ -1,0 +1,5 @@
+@mixin flicking {
+  overflow-y: hidden;
+  overflow-x: auto;
+  width: calc(100vw);
+}


### PR DESCRIPTION
## 👀 이슈
resolve #170 

## 📌 개요
flicking 라이브러리를 제거하고 css로 전환하는 작업을 거쳤습니다.

## 👩‍💻 작업 사항
- mixin에 flicking 역할을 하는 scss를 넣어두었습니다.
- 기존의 flicking 라이브러리 제거

## ✅ 참고 사항
 - 아래 ui가 공지사항쪽에도 사용되는 것 같은데 만약 같으면 공통 컴포넌트로 분리하려고 합니다. 이 부분 의견주시면 감사하겠습니다. 
<img width="633" alt="스크린샷 2022-04-21 오후 6 41 54" src="https://user-images.githubusercontent.com/22065725/164427550-f191c82c-8b62-482c-8561-5e130dd936be.png">

