### PR TITLE
mixin 말줄임 추가 

### DIFF
--- a/packages/mobile/src/page/Category/style.module.scss
+++ b/packages/mobile/src/page/Category/style.module.scss
@@ -180,6 +180,7 @@
 }
 
 .summary_title {
+  display: block;
   padding-top: 20px;
   color: $black-100;
   line-height: 18px;

--- a/packages/mobile/src/page/Category/style.module.scss
+++ b/packages/mobile/src/page/Category/style.module.scss
@@ -32,6 +32,8 @@
   font-weight: 500;
   line-height: 23px;
   color: $black-100;
+
+  @include ellipsis;
 }
 
 .button {
@@ -40,6 +42,7 @@
   font-size: 14px;
   line-height: 18px;
   background-color: inherit;
+  flex: 0 0 auto;
 }
 
 .menu {
@@ -95,7 +98,7 @@
 
 .hash {
   position: fixed;
-  top: 132px;
+  top: 131px;
   left: 0;
   right: 0;
   display: flex;
@@ -165,6 +168,7 @@
   width: 90px;
   height: 90px;
   border-radius: 20px;
+  flex: 0 0 auto;
 }
 
 .summary {
@@ -176,7 +180,6 @@
 }
 
 .summary_title {
-  display: block;
   padding-top: 20px;
   color: $black-100;
   line-height: 18px;

--- a/packages/shared/src/styles/mixin.scss
+++ b/packages/shared/src/styles/mixin.scss
@@ -3,3 +3,18 @@
   overflow-x: auto;
   width: calc(100vw);
 }
+
+@mixin ellipsis ($line : 1) {
+  @if($line == 1) {
+    display: block;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  } @else {
+    display: -webkit-box;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    -webkit-line-clamp: $line;
+    -webkit-box-orient: vertical;
+  }
+}


### PR DESCRIPTION
## 👀 이슈
resolve #196 

## 📌 개요
- mixin 말줄임을 추가하였습니다. 

## 👩‍💻 작업 사항
- mixin 말줄임임을 추가하였습니다(여러 줄 대응까지 가능)
- 해시태그 리스트 위치를 수정하였습니다. 

## ✅ 참고 사항
- `shared/src/styles/mixin.scss`에 추가해두었습니다. 
- 1줄일 때 뿐만 아니라 여러 줄일 때도 사용이 가능합니다.

- 사용 방법
   - 말줄임을 사용하고 싶은 곳에 @include로 추가
   ```scss
       // 1줄 
       @include ellipsis;

      // n줄 
       @include ellipsis(n);
   ``` 

<img width="564" alt="스크린샷 2022-04-24 오후 3 47 17" src="https://user-images.githubusercontent.com/22065725/164960729-1015a2d3-1ad4-4f19-8d33-dea135732969.png">

