### PR TITLE
[setting] Deploy shell에 git reset 명령어 추가

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,3 +1,4 @@
+git reset --hard
 git pull
 yarn
 yarn build:admin


### PR DESCRIPTION

## 📌 개요

deploy 서버에서 yarn install 이후 yan.lock 파일 때문에 pull에 실패하는 경우가 있어서 pull 하기전에 reset을 한번 해줍니다

## 👩‍💻 작업 사항

<!-- 작업한 내용을 적어주세요. -->

## ✅ 참고 사항

<!-- 공유할 내용, 스크린샷 등을 넣어 주세요. -->
