### PR TITLE
[server] 데이터베이스 스키마 Entity 구현

### DIFF
--- a/packages/server/src/commons/constants/enums.ts
+++ b/packages/server/src/commons/constants/enums.ts
@@ -3,3 +3,8 @@ export enum Authority {
   StudentCouncil = "StudentCouncil",
   Guest = "Guest",
 }
+
+export enum BoardAuthorityRole {
+  READ = "read",
+  WRITE = "write",
+}

--- a/packages/server/src/commons/entities/article.entity.ts
+++ b/packages/server/src/commons/entities/article.entity.ts
@@ -1,0 +1,26 @@
+import { Column, Entity, ManyToOne } from "typeorm";
+
+import { Admin } from "./admin.entity";
+import { Board } from "./board.entity";
+import { CommonEntity } from "./common.entity";
+
+@Entity({ name: "article" })
+export class Article extends CommonEntity {
+  @ManyToOne(() => Board, (Board) => Board.id)
+  board: number;
+
+  @ManyToOne(() => Admin, (Admin) => Admin.id)
+  author: number;
+
+  @Column({ type: "varchar" })
+  title: string;
+
+  @Column({ type: "text" })
+  content: string;
+
+  @Column({ type: "varchar", nullable: true })
+  url: string;
+
+  @Column({ type: "datetime" })
+  date: Date;
+}

--- a/packages/server/src/commons/entities/board-authority.entity.ts
+++ b/packages/server/src/commons/entities/board-authority.entity.ts
@@ -1,0 +1,32 @@
+import { IsEnum } from "class-validator";
+import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
+
+import { BoardAuthorityRole } from "../constants/enums";
+import { Admin } from "./admin.entity";
+import { Board } from "./board.entity";
+
+@Entity("board_authority")
+export class BoardAuthority {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => Board, (Board) => Board.id, {
+    cascade: true,
+    nullable: false,
+  })
+  board: number;
+
+  @ManyToOne(() => Admin, (Admin) => Admin.id, {
+    cascade: true,
+    nullable: false,
+  })
+  admin: number;
+
+  @Column({
+    type: "enum",
+    enum: BoardAuthorityRole,
+    default: BoardAuthorityRole.READ,
+  })
+  @IsEnum(BoardAuthorityRole)
+  role: BoardAuthorityRole;
+}

--- a/packages/server/src/commons/entities/bookmark.entity.ts
+++ b/packages/server/src/commons/entities/bookmark.entity.ts
@@ -1,0 +1,17 @@
+import { Entity, ManyToOne } from "typeorm";
+
+import { Article } from "./article.entity";
+import { CommonEntity } from "./common.entity";
+import { User } from "./user.entity";
+
+@Entity({ name: "bookmark" })
+export class Bookmark extends CommonEntity {
+  @ManyToOne(() => User, (User) => User.id, { cascade: true, nullable: false })
+  user: number;
+
+  @ManyToOne(() => Article, (Article) => Article.id, {
+    cascade: true,
+    nullable: false,
+  })
+  article: number;
+}

--- a/packages/server/src/commons/entities/certification.entity.ts
+++ b/packages/server/src/commons/entities/certification.entity.ts
@@ -1,0 +1,18 @@
+import { Column, Entity, OneToOne, PrimaryGeneratedColumn } from "typeorm";
+
+import { User } from "./user.entity";
+
+@Entity("certification")
+export class Certification {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @OneToOne(() => User, (User) => User.id, { cascade: true, nullable: false })
+  user: number;
+
+  @Column({ type: "varchar" })
+  number: string;
+ 
+  @Column({ type: "datetime" })
+  expireDate: Date;
+}

--- a/packages/server/src/commons/entities/common.entity.ts
+++ b/packages/server/src/commons/entities/common.entity.ts
@@ -1,4 +1,3 @@
-import { now } from "lodash";
 import {
   BaseEntity,
   CreateDateColumn,
@@ -12,13 +11,11 @@ export abstract class CommonEntity extends BaseEntity {
 
   @CreateDateColumn({
     type: "timestamp",
-    default: () => "CURRENT_TIMESTAMP",
   })
   createdAt: Date;
 
   @UpdateDateColumn({
     type: "timestamp",
-    default: () => "CURRENT_TIMESTAMP",
   })
   updatedAt: Date;
 }

--- a/packages/server/src/commons/entities/hit.entity.ts
+++ b/packages/server/src/commons/entities/hit.entity.ts
@@ -1,0 +1,17 @@
+import { Entity, ManyToOne } from "typeorm";
+
+import { Article } from "./article.entity";
+import { CommonEntity } from "./common.entity";
+import { User } from "./user.entity";
+
+@Entity("hit")
+export class Hit extends CommonEntity {
+  @ManyToOne(() => User, (User) => User.id, { cascade: true, nullable: false })
+  user: number;
+
+  @ManyToOne(() => Article, (Article) => Article.id, {
+    cascade: true,
+    nullable: false,
+  })
+  article: number;
+}

--- a/packages/server/src/commons/entities/image.entity.ts
+++ b/packages/server/src/commons/entities/image.entity.ts
@@ -1,0 +1,12 @@
+import { Column, Entity } from "typeorm";
+
+import { CommonEntity } from "./common.entity";
+
+@Entity({ name: "image" })
+export class Image extends CommonEntity {
+  @Column({ type: "int", nullable: true })
+  articleId?: number;
+
+  @Column({ type: "varchar" })
+  url: string;
+}

--- a/packages/server/src/commons/entities/notice-history.entity.ts
+++ b/packages/server/src/commons/entities/notice-history.entity.ts
@@ -1,0 +1,20 @@
+import { Column, Entity, ManyToOne } from "typeorm";
+
+import { Article } from "./article.entity";
+import { CommonEntity } from "./common.entity";
+import { User } from "./user.entity";
+
+@Entity("notice_history")
+export class NoticeHistory extends CommonEntity {
+  @ManyToOne(() => User, (User) => User.id, { cascade: true, nullable: false })
+  user: number;
+
+  @ManyToOne(() => Article, (Article) => Article.id, {
+    cascade: true,
+    nullable: false,
+  })
+  article: number;
+
+  @Column({ type: "boolean", default: false })
+  isConfirm: boolean;
+}

--- a/packages/server/src/commons/entities/report.entity.ts
+++ b/packages/server/src/commons/entities/report.entity.ts
@@ -1,0 +1,19 @@
+import { Column, Entity, ManyToOne } from "typeorm";
+
+import { CommonEntity } from "./common.entity";
+import { User } from "./user.entity";
+
+@Entity("report")
+export class Report extends CommonEntity {
+  @ManyToOne(() => User, (User) => User.id, { cascade: true, nullable: false })
+  user: number;
+
+  @Column({ type: "varchar" })
+  content: string;
+
+  @Column({ type: "tinyint", default: 0 })
+  resolve: number;
+
+  @Column({ type: "varchar", nullable: true })
+  comment: string;
+}

--- a/packages/server/src/commons/entities/subscribe.entity.ts
+++ b/packages/server/src/commons/entities/subscribe.entity.ts
@@ -1,0 +1,20 @@
+import { Column, Entity, ManyToOne } from "typeorm";
+
+import { Board } from "./board.entity";
+import { CommonEntity } from "./common.entity";
+import { User } from "./user.entity";
+
+@Entity("subscribe")
+export class Subscribe extends CommonEntity {
+  @ManyToOne(() => User, (User) => User.id, { cascade: true, nullable: false })
+  user: number;
+
+  @ManyToOne(() => Board, (Board) => Board.id, {
+    cascade: true,
+    nullable: false,
+  })
+  board: number;
+
+  @Column({ type: "tinyint", nullable: true })
+  notice: number;
+}


### PR DESCRIPTION
## 👀 이슈

resolve #

## 📌 개요

데이터베이스 스키마를 Entity로 구현하는 PR입니다.

- [x] admin
- [x] user
- [x] board_authority
- [x] board
- [x] board_tree
- [x] certification
- [x] article
- [x] hit
- [x] subscribe
- [x] bookmark
- [x] schedule
- [x] notice_history
- [x] place (server/i185에서 작업 @vcho1958 )
- [x] cafeteria (server/i185에서 작업 @vcho1958 )
- [x] caefeteria_menu (server/i185에서 작업 @vcho1958 )
- [x] report
- [x] Image
- [ ] weather (https://github.com/CMI-OSS/cbnu-alrami/pull/223)

## 👩‍💻 작업 사항

## ✅ 참고 사항

Entity와 데이터베이스 스키마 싱크를 맞추기 위함입니다.
따라서, 이 작업이 끝나면 sychronize: true로 설정할 계획입니다.