### PR TITLE
[admin] 에디터 스타일 버그 발생

### DIFF
--- a/packages/admin/src/components/Editor/style.module.scss
+++ b/packages/admin/src/components/Editor/style.module.scss
@@ -4,10 +4,11 @@
   width: 100%;
   margin: 1rem 0;
   background-color: $white;
-  div:nth-of-type(2) {
-    display: none;
-  }
-  div:nth-of-type(3) {
+  // div:nth-of-type(2) { // development
+  //   display: none;
+  // }
+  // div:nth-of-type(3) {
+  div:nth-of-type(2) { // production
     height: 36rem;
     font-size: 1rem;
     strong {


### PR DESCRIPTION
## 👀 이슈

resolve #246 

## 📌 개요

에디터 구조
```
react-quill
|-- toolbar
|-- toolbar
|-- container
```

[에디터에서 두 개의 toolbar가 나타나는 이슈](https://github.com/zenoamaro/react-quill/issues/800)
그로 인해 두 번째 toolbar를 없애기 위해
``` scss
div:nth-of-type(2) {
  display: none;
}
```
를 입력했지만 production환경에서는 `container`가 none되는 이슈 발생

## 👩‍💻 작업 사항

``` scss
.editor {
  width: 100%;
  margin: 1rem 0;
  background-color: $white;
  // div:nth-of-type(2) { // development
  //   display: none;
  // }
  // div:nth-of-type(3) {
  div:nth-of-type(2) { // production
    height: 36rem;
    font-size: 1rem;
    strong {
      font-weight: bold;
    }
    em {
      font-style: italic;
    }
  }
}
```

개발, 프로덕션 모드에서 각각 사용할 스타일 주석 처리 

## ✅ 참고 사항

`development - 두 번째 toolbar를 없애기 전`
<img width="1792" alt="스크린샷 2022-05-26 오후 4 28 00" src="https://user-images.githubusercontent.com/62797441/170439678-b42bb97d-aa5d-4368-9af0-ba0423548b50.png">

`development - 두 번째 toolbar를 없앤 후` 
<img width="1792" alt="스크린샷 2022-05-26 오후 4 26 27" src="https://user-images.githubusercontent.com/62797441/170439804-34952f94-483e-42bc-aee9-f6ee79285708.png">

`production`
<img width="1792" alt="스크린샷 2022-05-26 오후 4 19 45" src="https://user-images.githubusercontent.com/62797441/170438440-8a614ad1-8765-403f-8212-f0da8d25f6c9.png">

- 추가적인 공유가 필요한 사항은 Comment
