### PR TITLE
[mobile] 지도 - 이미지 페이지 작업

### DIFF
--- a/packages/mobile/src/App.tsx
+++ b/packages/mobile/src/App.tsx
@@ -10,6 +10,7 @@ import Calendar from "./page/Calendar";
 import Detail from "./page/Detail";
 import Home from "./page/Home";
 import Map from "./page/Map";
+import MoreImage from "./page/MoreImage";
 import Notification from "./page/Notification";
 import Place from "./page/Place";
 import { store } from "./store";
@@ -21,6 +22,7 @@ function App() {
     { id: 3, path: "/home", element: <Home /> },
     { id: 4, path: "/cafeteria", element: <Cafeteria /> },
     { id: 5, path: "/map", element: <Map /> },
+    { id: 6, path: "/more", element: <MoreImage /> },
   ];
 
   return (

--- a/packages/mobile/src/__mocks__/index.ts
+++ b/packages/mobile/src/__mocks__/index.ts
@@ -2,6 +2,7 @@ import constructionList from "./constructionList";
 import detailImageList from "./detailImageList";
 import foodList from "./foodList";
 import imageList from "./imageList";
+import mapImageList from "./mapImageList";
 import menuList from "./menuList";
 import playList from "./playList";
 import snackList from "./snackList";
@@ -14,4 +15,5 @@ export {
   playList,
   snackList,
   detailImageList,
+  mapImageList,
 };

--- a/packages/mobile/src/__mocks__/mapImageList.ts
+++ b/packages/mobile/src/__mocks__/mapImageList.ts
@@ -1,0 +1,114 @@
+const mapImageList = [
+  {
+    id: 1,
+    alt: "충북대학교 사회과학대학",
+    src: "https://search.pstatic.net/common/?autoRotate=true&quality=95&type=w750&src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20180130_263%2F1517301583613dwuaL_JPEG%2FZh5SeEjUT12rWxcLJ2nstPaB.jpg",
+  },
+  {
+    id: 2,
+    alt: "충북대학교 사회과학대학",
+    src: "https://search.pstatic.net/common/?autoRotate=true&quality=95&type=w750&src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20180130_263%2F1517301583613dwuaL_JPEG%2FZh5SeEjUT12rWxcLJ2nstPaB.jpg",
+  },
+  {
+    id: 3,
+    alt: "충북대학교 사회과학대학",
+    src: "https://search.pstatic.net/common/?autoRotate=true&quality=95&type=w750&src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20180130_263%2F1517301583613dwuaL_JPEG%2FZh5SeEjUT12rWxcLJ2nstPaB.jpg",
+  },
+  {
+    id: 4,
+    alt: "충북대학교 사회과학대학",
+    src: "https://search.pstatic.net/common/?autoRotate=true&quality=95&type=w750&src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20180130_263%2F1517301583613dwuaL_JPEG%2FZh5SeEjUT12rWxcLJ2nstPaB.jpg",
+  },
+  {
+    id: 5,
+    alt: "충북대학교 사회과학대학",
+    src: "https://search.pstatic.net/common/?autoRotate=true&quality=95&type=w750&src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20180130_263%2F1517301583613dwuaL_JPEG%2FZh5SeEjUT12rWxcLJ2nstPaB.jpg",
+  },
+  {
+    id: 6,
+    alt: "충북대학교 사회과학대학",
+    src: "https://search.pstatic.net/common/?autoRotate=true&quality=95&type=w750&src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20180130_263%2F1517301583613dwuaL_JPEG%2FZh5SeEjUT12rWxcLJ2nstPaB.jpg",
+  },
+  {
+    id: 7,
+    alt: "충북대학교 사회과학대학",
+    src: "https://search.pstatic.net/common/?autoRotate=true&quality=95&type=w750&src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20180130_263%2F1517301583613dwuaL_JPEG%2FZh5SeEjUT12rWxcLJ2nstPaB.jpg",
+  },
+  {
+    id: 8,
+    alt: "충북대학교 사회과학대학",
+    src: "https://search.pstatic.net/common/?autoRotate=true&quality=95&type=w750&src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20180130_263%2F1517301583613dwuaL_JPEG%2FZh5SeEjUT12rWxcLJ2nstPaB.jpg",
+  },
+  {
+    id: 9,
+    alt: "충북대학교 사회과학대학",
+    src: "https://search.pstatic.net/common/?autoRotate=true&quality=95&type=w750&src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20180130_263%2F1517301583613dwuaL_JPEG%2FZh5SeEjUT12rWxcLJ2nstPaB.jpg",
+  },
+  {
+    id: 10,
+    alt: "충북대학교 사회과학대학",
+    src: "https://search.pstatic.net/common/?autoRotate=true&quality=95&type=w750&src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20180130_263%2F1517301583613dwuaL_JPEG%2FZh5SeEjUT12rWxcLJ2nstPaB.jpg",
+  },
+  {
+    id: 11,
+    alt: "충북대학교 사회과학대학",
+    src: "https://search.pstatic.net/common/?autoRotate=true&quality=95&type=w750&src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20180130_263%2F1517301583613dwuaL_JPEG%2FZh5SeEjUT12rWxcLJ2nstPaB.jpg",
+  },
+  {
+    id: 12,
+    alt: "충북대학교 사회과학대학",
+    src: "https://search.pstatic.net/common/?autoRotate=true&quality=95&type=w750&src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20180130_263%2F1517301583613dwuaL_JPEG%2FZh5SeEjUT12rWxcLJ2nstPaB.jpg",
+  },
+  {
+    id: 13,
+    alt: "충북대학교 사회과학대학",
+    src: "https://search.pstatic.net/common/?autoRotate=true&quality=95&type=w750&src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20180130_263%2F1517301583613dwuaL_JPEG%2FZh5SeEjUT12rWxcLJ2nstPaB.jpg",
+  },
+  {
+    id: 14,
+    alt: "충북대학교 사회과학대학",
+    src: "https://search.pstatic.net/common/?autoRotate=true&quality=95&type=w750&src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20180130_263%2F1517301583613dwuaL_JPEG%2FZh5SeEjUT12rWxcLJ2nstPaB.jpg",
+  },
+  {
+    id: 15,
+    alt: "충북대학교 사회과학대학",
+    src: "https://search.pstatic.net/common/?autoRotate=true&quality=95&type=w750&src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20180130_263%2F1517301583613dwuaL_JPEG%2FZh5SeEjUT12rWxcLJ2nstPaB.jpg",
+  },
+  {
+    id: 16,
+    alt: "충북대학교 사회과학대학",
+    src: "https://search.pstatic.net/common/?autoRotate=true&quality=95&type=w750&src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20180130_263%2F1517301583613dwuaL_JPEG%2FZh5SeEjUT12rWxcLJ2nstPaB.jpg",
+  },
+  {
+    id: 17,
+    alt: "충북대학교 사회과학대학",
+    src: "https://search.pstatic.net/common/?autoRotate=true&quality=95&type=w750&src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20180130_263%2F1517301583613dwuaL_JPEG%2FZh5SeEjUT12rWxcLJ2nstPaB.jpg",
+  },
+  {
+    id: 18,
+    alt: "충북대학교 사회과학대학",
+    src: "https://search.pstatic.net/common/?autoRotate=true&quality=95&type=w750&src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20180130_263%2F1517301583613dwuaL_JPEG%2FZh5SeEjUT12rWxcLJ2nstPaB.jpg",
+  },
+  {
+    id: 19,
+    alt: "충북대학교 사회과학대학",
+    src: "https://search.pstatic.net/common/?autoRotate=true&quality=95&type=w750&src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20180130_263%2F1517301583613dwuaL_JPEG%2FZh5SeEjUT12rWxcLJ2nstPaB.jpg",
+  },
+  {
+    id: 20,
+    alt: "충북대학교 사회과학대학",
+    src: "https://search.pstatic.net/common/?autoRotate=true&quality=95&type=w750&src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20180130_263%2F1517301583613dwuaL_JPEG%2FZh5SeEjUT12rWxcLJ2nstPaB.jpg",
+  },
+  {
+    id: 21,
+    alt: "충북대학교 사회과학대학",
+    src: "https://search.pstatic.net/common/?autoRotate=true&quality=95&type=w750&src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20180130_263%2F1517301583613dwuaL_JPEG%2FZh5SeEjUT12rWxcLJ2nstPaB.jpg",
+  },
+  {
+    id: 22,
+    alt: "충북대학교 사회과학대학",
+    src: "https://search.pstatic.net/common/?autoRotate=true&quality=95&type=w750&src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20180130_263%2F1517301583613dwuaL_JPEG%2FZh5SeEjUT12rWxcLJ2nstPaB.jpg",
+  },
+];
+
+export default mapImageList;

--- a/packages/mobile/src/components/molecules/ImageList/index.tsx
+++ b/packages/mobile/src/components/molecules/ImageList/index.tsx
@@ -1,3 +1,5 @@
+import { NavLink } from "react-router-dom";
+
 import { ImagePlus } from "@components/atoms/icon/ImagePlus";
 
 import $ from "./style.module.scss";
@@ -21,10 +23,10 @@ function ImageList({ isMoreContents, detailImageList }: Props) {
             <li key={item.id} className={$["menu-item"]}>
               <img className={$["menu-image"]} src={item.src} alt={item.alt} />
               {isMoreContents && index === 2 && (
-                <div className={$["more-status"]}>
+                <NavLink to="/more" className={$["more-status"]}>
                   <ImagePlus className={$["more-plus"]} />
                   <span className={$["more-text"]}>더보기</span>
-                </div>
+                </NavLink>
               )}
             </li>
           </>

--- a/packages/mobile/src/components/molecules/MapHeader/index.tsx
+++ b/packages/mobile/src/components/molecules/MapHeader/index.tsx
@@ -1,0 +1,23 @@
+import { NavLink } from "react-router-dom";
+
+import { MapArrow } from "@components/atoms/icon/MapArrow";
+
+import $ from "./style.module.scss";
+
+type props = {
+  title: string;
+};
+
+function MapHeader({ title }: props) {
+  return (
+    <div className={$.header}>
+      <NavLink to="./" className={$.link}>
+        <MapArrow />
+        <span className="blind">뒤로 가기</span>
+      </NavLink>
+      <strong className={$.title}>{title}</strong>
+    </div>
+  );
+}
+
+export default MapHeader;

--- a/packages/mobile/src/components/molecules/MapHeader/index.tsx
+++ b/packages/mobile/src/components/molecules/MapHeader/index.tsx
@@ -4,11 +4,11 @@ import { MapArrow } from "@components/atoms/icon/MapArrow";
 
 import $ from "./style.module.scss";
 
-type props = {
+type Props = {
   title: string;
 };
 
-function MapHeader({ title }: props) {
+function MapHeader({ title }: Props) {
   return (
     <div className={$.header}>
       <NavLink to="./" className={$.link}>

--- a/packages/mobile/src/components/molecules/MapHeader/style.module.scss
+++ b/packages/mobile/src/components/molecules/MapHeader/style.module.scss
@@ -30,5 +30,5 @@
   color: $black-100;
   letter-spacing: 0.02em;
   text-align: center;
-  padding: 25px 20px 26px 50px;
+  padding: 25px 50px 26px;
 }

--- a/packages/mobile/src/components/molecules/MapHeader/style.module.scss
+++ b/packages/mobile/src/components/molecules/MapHeader/style.module.scss
@@ -1,0 +1,34 @@
+@import "@shared/styles/color.scss";
+@import "@shared/styles/mixin.scss";
+@import "../../../styles/main.scss";
+
+.header {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 100;
+  background-color: $white;
+  height: 70px;
+}
+
+.link {
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: inline-block;
+  max-height: 70px;
+  padding: 25px 22px 26px;
+}
+
+.title {
+  @include typography(18);
+  @include ellipsis;
+  display: block;
+  font-weight: 500;
+  color: $black-100;
+  letter-spacing: 0.02em;
+  text-align: center;
+  padding: 25px 20px 26px 50px;
+}

--- a/packages/mobile/src/components/molecules/MapImageList/index.tsx
+++ b/packages/mobile/src/components/molecules/MapImageList/index.tsx
@@ -1,0 +1,25 @@
+import $ from "./style.module.scss";
+
+type mapImageListType = {
+  id: number;
+  src: string;
+  alt: string;
+};
+
+type Props = {
+  mapImageList: mapImageListType[];
+};
+
+function MapImageList({ mapImageList }: Props) {
+  return (
+    <ul className={$.list}>
+      {mapImageList.map((item) => (
+        <li key={item.id} className={$.item}>
+          <img className={$.image} src={item.src} alt={item.alt} />
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export default MapImageList;

--- a/packages/mobile/src/components/molecules/MapImageList/style.module.scss
+++ b/packages/mobile/src/components/molecules/MapImageList/style.module.scss
@@ -1,0 +1,15 @@
+.list {
+  display: flex;
+  flex-wrap: wrap;
+  padding-top: 70px;
+  margin-top: -3px;
+}
+
+.item {
+  margin: 3px 2px 0 0;
+}
+
+.image {
+  width: 123px;
+  height: 123px;
+}

--- a/packages/mobile/src/page/MoreImage/index.tsx
+++ b/packages/mobile/src/page/MoreImage/index.tsx
@@ -1,0 +1,13 @@
+import MapHeader from "@components/molecules/MapHeader";
+
+import $ from "./style.module.scss";
+
+function MoreImage() {
+  return (
+    <>
+      <MapHeader title="이미지" />
+    </>
+  );
+}
+
+export default MoreImage;

--- a/packages/mobile/src/page/MoreImage/index.tsx
+++ b/packages/mobile/src/page/MoreImage/index.tsx
@@ -1,11 +1,14 @@
 import MapHeader from "@components/molecules/MapHeader";
+import MapImageList from "@components/molecules/MapImageList";
 
+import mapImageList from "../../__mocks__/mapImageList";
 import $ from "./style.module.scss";
 
 function MoreImage() {
   return (
     <>
       <MapHeader title="이미지" />
+      <MapImageList mapImageList={mapImageList} />
     </>
   );
 }


### PR DESCRIPTION
## 👀 이슈
resolve #251 

## 📌 개요
- mobile 지도 이미지 리스트 페이지 작업을 진행하였습니다.

## 👩‍💻 작업 사항
- `MoreImage`라는 컴포넌트를 작성하였습니다.
- `MapHeader`는 mobile 지도쪽에서 다른 컴포넌트를 만들 때도 동일하게 사용할 것 같아서 `title` props를 따로 주고 진행하였습니다. 

## ✅ 참고 사항
- https://www.figma.com/file/fCzuV7VJDKWY9N6J89XKV0/%EC%B6%A9%EB%A6%BC%EC%9D%B4?node-id=953%3A1350
<img width="369" alt="스크린샷 2022-06-06 오후 5 15 01" src="https://user-images.githubusercontent.com/22065725/172122576-b4e43ec0-1c9b-4f77-9c09-4c9116568e4c.png">
- url: http://localhost:3000/more