### PR TITLE
[server] article_image 테이블 생성

### DIFF
--- a/packages/server/src/commons/entities/article.entity.ts
+++ b/packages/server/src/commons/entities/article.entity.ts
@@ -4,7 +4,7 @@ import { Admin } from "./admin.entity";
 import { Board } from "./board.entity";
 import { CommonEntity } from "./common.entity";
 
-@Entity({ name: "article" })
+@Entity()
 export class Article extends CommonEntity {
   @ManyToOne(() => Board, (Board) => Board.id)
   board: Board;

--- a/packages/server/src/commons/entities/articleImage.entity.ts
+++ b/packages/server/src/commons/entities/articleImage.entity.ts
@@ -1,0 +1,16 @@
+import { Entity, JoinColumn, ManyToOne } from "typeorm";
+
+import { Article } from "./article.entity";
+import { CommonEntity } from "./common.entity";
+import { Image } from "./image.entity";
+
+@Entity()
+export class ArticleImage extends CommonEntity {
+  @ManyToOne(() => Article, (Article) => Article.id)
+  @JoinColumn()
+  article: Article;
+
+  @ManyToOne(() => Image, (Image) => Image.id)
+  @JoinColumn()
+  image: Image;
+}

--- a/packages/server/src/commons/entities/board.entity.ts
+++ b/packages/server/src/commons/entities/board.entity.ts
@@ -1,9 +1,7 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { Entity, Column, PrimaryGeneratedColumn, OneToMany } from "typeorm";
+import { Column, Entity, PrimaryGeneratedColumn } from "typeorm";
 
-import { BoardTree } from "./boardTree.entity";
-
-@Entity({ name: "board" })
+@Entity()
 export class Board {
   @PrimaryGeneratedColumn()
   @ApiProperty({ description: "pk" })

--- a/packages/server/src/commons/entities/boardAuthority.entity.ts
+++ b/packages/server/src/commons/entities/boardAuthority.entity.ts
@@ -11,7 +11,7 @@ import { BoardAuthorityRole } from "../constants/enums";
 import { Admin } from "./admin.entity";
 import { Board } from "./board.entity";
 
-@Entity("board_authority")
+@Entity()
 export class BoardAuthority {
   @PrimaryGeneratedColumn()
   id: number;

--- a/packages/server/src/commons/entities/boardTree.entity.ts
+++ b/packages/server/src/commons/entities/boardTree.entity.ts
@@ -3,7 +3,7 @@ import { Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn } from "typeorm";
 
 import { Board } from "./board.entity";
 
-@Entity({ name: "board_tree" })
+@Entity()
 export class BoardTree {
   @PrimaryGeneratedColumn()
   @ApiProperty({ description: "pk" })

--- a/packages/server/src/commons/entities/bookmark.entity.ts
+++ b/packages/server/src/commons/entities/bookmark.entity.ts
@@ -4,7 +4,7 @@ import { Article } from "./article.entity";
 import { CommonEntity } from "./common.entity";
 import { User } from "./user.entity";
 
-@Entity({ name: "bookmark" })
+@Entity()
 export class Bookmark extends CommonEntity {
   @ManyToOne(() => User, (User) => User.id, { cascade: true, nullable: false })
   @JoinColumn()

--- a/packages/server/src/commons/entities/cafeteriaMenu.entity.ts
+++ b/packages/server/src/commons/entities/cafeteriaMenu.entity.ts
@@ -6,8 +6,8 @@ import { CommonEntity } from "./common.entity";
 
 @Entity()
 export class CafeteriaMenu extends CommonEntity {
-  @ManyToOne(() => Cafeteria, cafeteria => cafeteria.cafeteriaMenus)
-  @JoinColumn({name: 'cafeteria_id'})
+  @ManyToOne(() => Cafeteria, (cafeteria) => cafeteria.cafeteriaMenus)
+  @JoinColumn({ name: "cafeteria_id" })
   cafeteria: Cafeteria;
 
   @Column("varchar", { nullable: false })

--- a/packages/server/src/commons/entities/certification.entity.ts
+++ b/packages/server/src/commons/entities/certification.entity.ts
@@ -8,7 +8,7 @@ import {
 
 import { User } from "./user.entity";
 
-@Entity("certification")
+@Entity()
 export class Certification {
   @PrimaryGeneratedColumn()
   id: number;

--- a/packages/server/src/commons/entities/hit.entity.ts
+++ b/packages/server/src/commons/entities/hit.entity.ts
@@ -4,7 +4,7 @@ import { Article } from "./article.entity";
 import { CommonEntity } from "./common.entity";
 import { User } from "./user.entity";
 
-@Entity("hit")
+@Entity()
 export class Hit extends CommonEntity {
   @ManyToOne(() => User, (User) => User.id, { cascade: true, nullable: false })
   @JoinColumn()

--- a/packages/server/src/commons/entities/image.entity.ts
+++ b/packages/server/src/commons/entities/image.entity.ts
@@ -2,7 +2,7 @@ import { Column, Entity } from "typeorm";
 
 import { CommonEntity } from "./common.entity";
 
-@Entity({ name: "image" })
+@Entity()
 export class Image extends CommonEntity {
   @Column({ type: "varchar" })
   url: string;

--- a/packages/server/src/commons/entities/image.entity.ts
+++ b/packages/server/src/commons/entities/image.entity.ts
@@ -1,14 +1,9 @@
-import { Column, Entity, JoinColumn, ManyToOne } from "typeorm";
+import { Column, Entity } from "typeorm";
 
-import { Article } from "./article.entity";
 import { CommonEntity } from "./common.entity";
 
 @Entity({ name: "image" })
 export class Image extends CommonEntity {
-  @ManyToOne(() => Article, (Article) => Article.id, { nullable: true })
-  @JoinColumn()
-  article?: Article;
-
   @Column({ type: "varchar" })
   url: string;
 }

--- a/packages/server/src/commons/entities/noticeHistory.entity.ts
+++ b/packages/server/src/commons/entities/noticeHistory.entity.ts
@@ -4,7 +4,7 @@ import { Article } from "./article.entity";
 import { CommonEntity } from "./common.entity";
 import { User } from "./user.entity";
 
-@Entity("notice_history")
+@Entity()
 export class NoticeHistory extends CommonEntity {
   @ManyToOne(() => User, (User) => User.id, { cascade: true, nullable: false })
   @JoinColumn()

--- a/packages/server/src/commons/entities/report.entity.ts
+++ b/packages/server/src/commons/entities/report.entity.ts
@@ -3,7 +3,7 @@ import { Column, Entity, JoinColumn, ManyToOne } from "typeorm";
 import { CommonEntity } from "./common.entity";
 import { User } from "./user.entity";
 
-@Entity("report")
+@Entity()
 export class Report extends CommonEntity {
   @ManyToOne(() => User, (User) => User.id, { cascade: true, nullable: false })
   @JoinColumn()

--- a/packages/server/src/commons/entities/schedule.entity.ts
+++ b/packages/server/src/commons/entities/schedule.entity.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from "@nestjs/swagger";
 import { Column, Entity, PrimaryGeneratedColumn } from "typeorm";
 
-@Entity({ name: "schedule" })
+@Entity()
 export class Schedule {
   @PrimaryGeneratedColumn()
   @ApiProperty({ description: "PK" })

--- a/packages/server/src/commons/entities/subscribe.entity.ts
+++ b/packages/server/src/commons/entities/subscribe.entity.ts
@@ -4,7 +4,7 @@ import { Board } from "./board.entity";
 import { CommonEntity } from "./common.entity";
 import { User } from "./user.entity";
 
-@Entity("subscribe")
+@Entity()
 export class Subscribe extends CommonEntity {
   @ManyToOne(() => User, (User) => User.id, { cascade: true, nullable: false })
   @JoinColumn()

--- a/packages/server/src/commons/entities/weather.entity.ts
+++ b/packages/server/src/commons/entities/weather.entity.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from "@nestjs/swagger";
 import { Column, Entity, PrimaryGeneratedColumn } from "typeorm";
 
-@Entity({ name: "weather" })
+@Entity()
 export class Weather {
   @ApiProperty({ description: "PK" })
   @PrimaryGeneratedColumn({ type: "int" })


### PR DESCRIPTION
## 👀 이슈

resolve #275 

## 📌 개요

article_image 테이블을 생성합니다.

## 👩‍💻 작업 사항

article 생성 시 이미지를 먼저 image 테이블에 저장하고, article_image에 article과 image를 매핑해 저장합니다.

## ✅ 참고 사항

<img width="769" alt="image" src="https://user-images.githubusercontent.com/80724255/177042493-c3680cbb-f381-4679-8247-0094eadfe9ad.png">
