### PR TITLE
[server] 오픈 API를 통한 공휴일 데이터 저장 Batch 구현 

### DIFF
--- a/packages/server/src/app.module.ts
+++ b/packages/server/src/app.module.ts
@@ -15,7 +15,7 @@ import { JwtGuard } from "./commons/guards/jwt.guard";
 import { FcmModule } from "./fcm/fcm.module";
 import { ImageModule } from "./image/image.module";
 import { PlaceModule } from "./place/place.module";
-import { ScheduleModule } from "./schedule/schedule.module";
+import { SchedulesModule } from "./schedule/schedule.module";
 import { WeatherModule } from "./weather/weather.module";
 
 @Module({
@@ -42,7 +42,7 @@ import { WeatherModule } from "./weather/weather.module";
     BoardModule,
     CafeteriaModule,
     PlaceModule,
-    ScheduleModule,
+    SchedulesModule,
     WeatherModule,
   ],
   providers: [

--- a/packages/server/src/commons/entities/schedule.entity.ts
+++ b/packages/server/src/commons/entities/schedule.entity.ts
@@ -8,7 +8,7 @@ export class Schedule {
   id: number;
 
   @ApiProperty({ description: "학사 내용" })
-  @Column({ type: "varchar", length: 50, unique: true })
+  @Column({ type: "varchar", length: 50 })
   content: string;
 
   @ApiProperty({ description: "우선 순위", required: false })
@@ -16,7 +16,7 @@ export class Schedule {
   priority?: number;
 
   @ApiProperty({ description: "공휴일 여부", required: false })
-  @Column({ type: "tinyint", nullable: true })
+  @Column({ type: "boolean", nullable: true })
   isHoliday?: number;
 
   @ApiProperty({ description: "일정 시작일" })

--- a/packages/server/src/schedule/schedule.module.ts
+++ b/packages/server/src/schedule/schedule.module.ts
@@ -1,4 +1,6 @@
+import { HttpModule } from "@nestjs/axios";
 import { Module } from "@nestjs/common";
+import { ScheduleModule } from "@nestjs/schedule";
 import { TypeOrmModule } from "@nestjs/typeorm";
 
 import { ScheduleController } from "./schedule.controller";
@@ -6,8 +8,12 @@ import { ScheduleRepository } from "./schedule.repository";
 import { ScheduleService } from "./schedule.service";
 
 @Module({
-  imports: [ TypeOrmModule.forFeature([ ScheduleRepository ]) ],
+  imports: [
+    TypeOrmModule.forFeature([ ScheduleRepository ]),
+    HttpModule,
+    ScheduleModule.forRoot(),
+  ],
   providers: [ ScheduleService ],
   controllers: [ ScheduleController ],
 })
-export class ScheduleModule {}
+export class SchedulesModule {}

--- a/packages/server/src/schedule/schedule.repository.ts
+++ b/packages/server/src/schedule/schedule.repository.ts
@@ -1,4 +1,4 @@
-import { EntityRepository, Repository } from "typeorm";
+import { EntityRepository, InsertResult, Repository } from "typeorm";
 
 import { Schedule } from "../commons/entities/schedule.entity";
 import { GetSchedulesRequestDto } from "./dtos/get-schedules-request.dto";
@@ -30,7 +30,7 @@ export class ScheduleRepository extends Repository<Schedule> {
       .getMany();
   }
 
-  async saveHoliday(content, startDate) {
+  async saveHoliday(content: string, startDate: Date): Promise<InsertResult> {
     return this.createQueryBuilder()
       .insert()
       .into(Schedule)

--- a/packages/server/src/schedule/schedule.repository.ts
+++ b/packages/server/src/schedule/schedule.repository.ts
@@ -29,4 +29,16 @@ export class ScheduleRepository extends Repository<Schedule> {
       .addOrderBy("startDate", "ASC")
       .getMany();
   }
+
+  async saveHoliday(content, startDate) {
+    return this.createQueryBuilder()
+      .insert()
+      .into(Schedule)
+      .values({
+        content: `${content}`,
+        isHoliday: 1,
+        startDate: `${startDate}`,
+      })
+      .execute();
+  }
 }

--- a/packages/server/src/schedule/schedule.service.ts
+++ b/packages/server/src/schedule/schedule.service.ts
@@ -10,9 +10,9 @@ import { ScheduleRepository } from "./schedule.repository";
 
 interface holidayData {
   dateKind: "01";
-  dateName?: string | undefined;
+  dateName: string;
   isHoliday: "Y";
-  locdate?: Date | undefined;
+  locdate: Date;
   seq: 1;
 }
 
@@ -61,6 +61,10 @@ export class ScheduleService {
 
     const holidayData: holidayData[] = holiday.data.response.body.items.item;
 
+    this.saveHoliday(holidayData);
+  }
+
+  private saveHoliday(holidayData): void {
     holidayData.map(async (holiday) => {
       const { dateName, locdate } = holiday;
 

--- a/packages/server/src/schedule/schedule.service.ts
+++ b/packages/server/src/schedule/schedule.service.ts
@@ -1,12 +1,39 @@
+import { HttpService } from "@nestjs/axios";
 import { Injectable } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { Cron } from "@nestjs/schedule";
+import { firstValueFrom } from "rxjs";
 
 import { Schedule } from "../commons/entities/schedule.entity";
 import { GetSchedulesRequestDto } from "./dtos/get-schedules-request.dto";
 import { ScheduleRepository } from "./schedule.repository";
 
+interface holidayData {
+  dateKind: "01";
+  dateName?: string | undefined;
+  isHoliday: "Y";
+  locdate?: Date | undefined;
+  seq: 1;
+}
+
 @Injectable()
 export class ScheduleService {
-  constructor(private readonly scheduleRepository: ScheduleRepository) {}
+  private readonly holidayKey;
+  private readonly holidayUrl;
+
+  constructor(
+    private readonly scheduleRepository: ScheduleRepository,
+    private readonly httpService: HttpService,
+    private readonly configService: ConfigService,
+  ) {
+    this.holidayKey = this.configService.get("holiday.key");
+    this.holidayUrl = this.configService.get("holiday.url");
+  }
+
+  private static getYear(): number {
+    const today = new Date();
+    return today.getFullYear();
+  }
 
   public getSchedules(
     getSchedulesRequestDto: GetSchedulesRequestDto,
@@ -17,5 +44,58 @@ export class ScheduleService {
       return this.scheduleRepository.getDailySchedules(startDate);
     }
     return this.scheduleRepository.getSchedules(getSchedulesRequestDto);
+  }
+
+  @Cron("0 0 0 1 1 *")
+  public async getHolidays(): Promise<void> {
+    const url = `${this.holidayUrl}`;
+
+    const serviceKey = `?ServiceKey=${this.holidayKey}`;
+
+    const year = ScheduleService.getYear();
+    const solYear = `&solYear=${year}`;
+
+    const months = [
+      "01",
+      "02",
+      "03",
+      "04",
+      "05",
+      "06",
+      "07",
+      "08",
+      "09",
+      "10",
+      "11",
+      "12",
+    ];
+
+    await Promise.all(
+      months.map(async (month) => {
+        const solMonth = `&solMonth=${month}`;
+
+        const holiday = await firstValueFrom(
+          this.httpService.get(`${url}${serviceKey}${solYear}${solMonth}`),
+        );
+
+        const holidayData: holidayData | holidayData[] =
+          holiday.data.response.body.items.item;
+
+        if (Array.isArray(holidayData)) {
+          holidayData.map(async (holiday) => {
+            const { dateName, locdate } = holiday;
+
+            if (dateName && locdate) {
+              await this.scheduleRepository.saveHoliday(dateName, locdate);
+            }
+          });
+        } else if (holidayData?.dateName && holidayData?.locdate) {
+          await this.scheduleRepository.saveHoliday(
+            holidayData.dateName,
+            holidayData.locdate,
+          );
+        }
+      }),
+    );
   }
 }

--- a/packages/server/src/schedule/schedule.service.ts
+++ b/packages/server/src/schedule/schedule.service.ts
@@ -61,14 +61,16 @@ export class ScheduleService {
 
     const holidayData: holidayData[] = holiday.data.response.body.items.item;
 
-    this.saveHoliday(holidayData);
+    await this.saveHoliday(holidayData);
   }
 
-  private saveHoliday(holidayData): void {
-    holidayData.map(async (holiday) => {
-      const { dateName, locdate } = holiday;
+  private async saveHoliday(holidayData): Promise<void> {
+    await Promise.all(
+      holidayData.map(async (holiday) => {
+        const { dateName, locdate } = holiday;
 
-      await this.scheduleRepository.saveHoliday(dateName, locdate);
-    });
+        return this.scheduleRepository.saveHoliday(dateName, locdate);
+      }),
+    );
   }
 }

--- a/packages/server/src/weather/weather.service.ts
+++ b/packages/server/src/weather/weather.service.ts
@@ -2,6 +2,7 @@ import { HttpService } from "@nestjs/axios";
 import { Injectable } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { Cron } from "@nestjs/schedule";
+import { firstValueFrom } from "rxjs";
 
 import { GetWeatherResponseDto } from "./dtos/get-weather.response.dto";
 import { WeatherRepository } from "./weather.repository";
@@ -37,15 +38,15 @@ export class WeatherService {
 
   @Cron("0 0 0 * * *")
   async createWeathers(): Promise<void> {
-    const weather = await this.httpService
-      .get(
+    const weather = await firstValueFrom(
+      await this.httpService.get(
         `https://api.openweathermap.org/data/2.5/onecall?lat=36.62858542513084&lon=127.45748680644566&appid=${this.weatherKey}&lang=kr&exclude=current,minutely,daily,alerts&units=metric`,
-      )
-      .toPromise();
+      ),
+    );
 
     const todayTemp: number[] = [];
     const todayWeather: string[] = [];
-
+ 
     weather.data.hourly.forEach((data) => {
       if (new Date(data.dt * 1000).getDate() === new Date().getDate()) {
         todayTemp.push(data.temp);
@@ -76,11 +77,11 @@ export class WeatherService {
 
   @Cron("5 0 */1 * * *")
   async createCurrentWeather(): Promise<void> {
-    const weather = await this.httpService
-      .get(
+    const weather = await firstValueFrom(
+      await this.httpService.get(
         `https://api.openweathermap.org/data/2.5/onecall?lat=36.62858542513084&lon=127.45748680644566&appid=${this.weatherKey}&lang=kr&exclude=minutely,hourly,daily,alerts&units=metric`,
-      )
-      .toPromise();
+      ),
+    );
 
     const currentTemp = weather.data.current.temp;
     const currentWeather = weather.data.current.weather[0].main;


### PR DESCRIPTION
## 👀 이슈

resolve #279

## 📌 개요

오픈 API를 통한 공휴일 데이터 저장 Batch를 구현합니다.

## 👩‍💻 작업 사항

1년에 한번(1월 1일) 공휴일 정보 API를 통해 공휴일 데이터를 가져와 데이터베이스 Schedule 테이블에 저장합니다.

## ✅ 참고 사항

오픈 API: https://www.data.go.kr/data/15012690/openapi.do