### PR TITLE
[server] subscribe entity notice 필드 자료형 수정

### DIFF
--- a/packages/server/src/commons/entities/subscribe.entity.ts
+++ b/packages/server/src/commons/entities/subscribe.entity.ts
@@ -17,6 +17,6 @@ export class Subscribe extends CommonEntity {
   @JoinColumn()
   board: Board;
 
-  @Column({ type: "tinyint", nullable: true })
-  notice: number;
+  @Column({ type: "bool", width: 1, nullable: true })
+  notice: boolean;
 }


### PR DESCRIPTION
## 👀 이슈

resolve #293 

## 📌 개요

- 알림 여부를 의미하는 Notice필드를 boolean으로 수정합니다. 

## 👩‍💻 작업 사항

- subscribe entity의 notice 필드 자료형을 tinyint(number) -> bool (boolean)으로 수정

## ✅ 참고 사항

참고 : https://github.com/typeorm/typeorm/issues/3622
