### PR TITLE
[server] 보드 계층 조회 API response 수정

### DIFF
--- a/packages/server/src/app.module.ts
+++ b/packages/server/src/app.module.ts
@@ -18,6 +18,7 @@ import { HitModule } from "./hit/hit.module";
 import { ImageModule } from "./image/image.module";
 import { PlaceModule } from "./place/place.module";
 import { SchedulesModule } from "./schedule/schedule.module";
+import { SubscribeModule } from "./subscribe/subscribe.module";
 import { UserModule } from "./user/user.module";
 import { WeatherModule } from "./weather/weather.module";
 
@@ -49,6 +50,7 @@ import { WeatherModule } from "./weather/weather.module";
     CafeteriaModule,
     PlaceModule,
     SchedulesModule,
+    SubscribeModule,
     WeatherModule,
     HitModule,
     JwtModule.register({

--- a/packages/server/src/article/article.module.ts
+++ b/packages/server/src/article/article.module.ts
@@ -1,10 +1,8 @@
 import { Module } from "@nestjs/common";
 import { TypeOrmModule } from "@nestjs/typeorm";
 import { AdminModule } from "src/admin/admin.module";
-import { AdminService } from "src/admin/admin.service";
 import { ArticleImageRepository } from "src/articleImage/articleImage.repository";
 import { ArticleImageService } from "src/articleImage/articleImage.service";
-import { BoardModule } from "src/board/board.module";
 import { BoardRepository } from "src/board/board.repository";
 import { BoardService } from "src/board/board.service";
 import { BoardTreeRepository } from "src/boardTree/boardTree.repository";
@@ -14,6 +12,8 @@ import { HitRepository } from "src/hit/hit.repository";
 import { AwsService } from "src/image/aws.service";
 import { ImageRepository } from "src/image/image.repository";
 import { ImageService } from "src/image/image.service";
+import { SubscribeRepository } from "src/subscribe/subscribe.repository";
+import { SubscribeService } from "src/subscribe/subscribe.service";
 
 import { ArticleController } from "./article.controller";
 import { ArticleRepository } from "./article.repository";
@@ -29,6 +29,7 @@ import { ArticleService } from "./article.service";
       HitRepository,
       ArticleImageRepository,
       ImageRepository,
+      SubscribeRepository,
     ]),
     AdminModule,
   ],
@@ -39,6 +40,7 @@ import { ArticleService } from "./article.service";
     BoardTreeService,
     AwsService,
     ArticleImageService,
+    SubscribeService,
     ImageService,
   ],
 })

--- a/packages/server/src/boardTree/boardTree.controller.ts
+++ b/packages/server/src/boardTree/boardTree.controller.ts
@@ -1,6 +1,7 @@
-import { Controller, Get, Param } from "@nestjs/common";
+import { Controller, Get, Param, Req, UseGuards } from "@nestjs/common";
 import { ApiOperation, ApiResponse, ApiTags } from "@nestjs/swagger";
 import { Public } from "src/commons/decorators/public.decorator";
+import { UserAuthGuard } from "src/commons/guards/user-auth.guard";
 
 import { BoardTreeService } from "./boardTree.service";
 import { BoardTreeAllResponseDto } from "./dto/boardTree.all.response.dto";
@@ -25,8 +26,10 @@ export class BoardTreeController {
     type: BoardTreeAllResponseDto,
     isArray: true,
   })
-  async findAll() {
-    return this.boardTreeService.findAll();
+  @UseGuards(UserAuthGuard)
+  async findAll(@Req() req) {
+    const { user } = req;
+    return this.boardTreeService.findAll(user);
   }
 
   @Get(":boardId")

--- a/packages/server/src/boardTree/boardTree.controller.ts
+++ b/packages/server/src/boardTree/boardTree.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Get, Param, Req, UseGuards } from "@nestjs/common";
-import { ApiOperation, ApiResponse, ApiTags } from "@nestjs/swagger";
+import { ApiHeader, ApiOperation, ApiResponse, ApiTags } from "@nestjs/swagger";
 import { Public } from "src/commons/decorators/public.decorator";
 import { UserAuthGuard } from "src/commons/guards/user-auth.guard";
 
@@ -25,6 +25,10 @@ export class BoardTreeController {
     description: "공지사항 사이트 전체 계층 구조",
     type: BoardTreeAllResponseDto,
     isArray: true,
+  })
+  @ApiHeader({
+    name: "uuid",
+    description: "user uuid",
   })
   @UseGuards(UserAuthGuard)
   async findAll(@Req() req) {

--- a/packages/server/src/boardTree/boardTree.controller.ts
+++ b/packages/server/src/boardTree/boardTree.controller.ts
@@ -29,7 +29,7 @@ export class BoardTreeController {
   @UseGuards(UserAuthGuard)
   async findAll(@Req() req) {
     const { user } = req;
-    return this.boardTreeService.findAll(user);
+    return this.boardTreeService.findAll(user.id);
   }
 
   @Get(":boardId")

--- a/packages/server/src/boardTree/boardTree.module.ts
+++ b/packages/server/src/boardTree/boardTree.module.ts
@@ -2,14 +2,22 @@ import { Module } from "@nestjs/common";
 import { TypeOrmModule } from "@nestjs/typeorm";
 import { BoardRepository } from "src/board/board.repository";
 import { BoardService } from "src/board/board.service";
+import { SubscribeRepository } from "src/subscribe/subscribe.repository";
+import { SubscribeService } from "src/subscribe/subscribe.service";
 
 import { BoardTreeController } from "./boardTree.controller";
 import { BoardTreeRepository } from "./boardTree.repository";
 import { BoardTreeService } from "./boardTree.service";
 
 @Module({
-  imports: [ TypeOrmModule.forFeature([ BoardTreeRepository, BoardRepository ]) ],
+  imports: [
+    TypeOrmModule.forFeature([
+      BoardTreeRepository,
+      BoardRepository,
+      SubscribeRepository,
+    ]),
+  ],
   controllers: [ BoardTreeController ],
-  providers: [ BoardTreeService, BoardService ],
+  providers: [ BoardTreeService, BoardService, SubscribeService ],
 })
 export class BoardTreeModule {}

--- a/packages/server/src/boardTree/boardTree.service.ts
+++ b/packages/server/src/boardTree/boardTree.service.ts
@@ -3,7 +3,6 @@ import { Builder } from "builder-pattern";
 import { BoardResponseDto } from "src/board/dto/board.response.dto";
 import { BoardTree } from "src/commons/entities/boardTree.entity";
 import { Subscribe } from "src/commons/entities/subscribe.entity";
-import { User } from "src/commons/entities/user.entity";
 import { Errors } from "src/commons/exception/exception.global";
 import { SubscribeService } from "src/subscribe/subscribe.service";
 
@@ -51,7 +50,7 @@ export class BoardTreeService {
       .build();
   }
 
-  async findAll(user: User) {
+  async findAll(userId: number) {
     const rootList: BoardTree[] = await this.boardTreeRepository.find({
       where: {
         parentBoard: null,
@@ -63,7 +62,7 @@ export class BoardTreeService {
 
     await Promise.all(
       rootList.map(async (root) => {
-        const children = await this.findChildren(root.board.id, user.id);
+        const children = await this.findChildren(root.board.id, userId);
         response.push(
           Builder(BoardTreeAllResponseDto)
             .id(root.board.id)

--- a/packages/server/src/boardTree/boardTree.service.ts
+++ b/packages/server/src/boardTree/boardTree.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from "@nestjs/common";
 import { Builder } from "builder-pattern";
 import { BoardResponseDto } from "src/board/dto/board.response.dto";
 import { BoardTree } from "src/commons/entities/boardTree.entity";
+import { User } from "src/commons/entities/user.entity";
 import { Errors } from "src/commons/exception/exception.global";
 
 import { BoardTreeRepository } from "./boardTree.repository";
@@ -45,7 +46,7 @@ export class BoardTreeService {
       .build();
   }
 
-  async findAll() {
+  async findAll(user: User) {
     const rootList: BoardTree[] = await this.boardTreeRepository.find({
       where: {
         parentBoard: null,

--- a/packages/server/src/boardTree/dto/boardTree.all.response.dto.ts
+++ b/packages/server/src/boardTree/dto/boardTree.all.response.dto.ts
@@ -10,6 +10,12 @@ export class BoardTreeAllResponseDto {
   @ApiProperty({ description: "board url" })
   url!: string;
 
+  @ApiProperty({ description: "구독 여부" })
+  isSubscribing!: boolean;
+
+  @ApiProperty({ description: "알림 여부" })
+  isNoticing!: boolean;
+
   @ApiProperty({ description: "하위 board" })
   children: BoardTreeAllResponseDto[];
 }

--- a/packages/server/src/subscribe/subscribe.module.ts
+++ b/packages/server/src/subscribe/subscribe.module.ts
@@ -1,0 +1,11 @@
+import { Module } from "@nestjs/common";
+import { TypeOrmModule } from "@nestjs/typeorm";
+
+import { SubscribeRepository } from "./subscribe.repository";
+import { SubscribeService } from "./subscribe.service";
+
+@Module({
+  imports: [ TypeOrmModule.forFeature([ SubscribeRepository ]) ],
+  providers: [ SubscribeService ],
+})
+export class SubscribeModule {}

--- a/packages/server/src/subscribe/subscribe.repository.ts
+++ b/packages/server/src/subscribe/subscribe.repository.ts
@@ -1,0 +1,5 @@
+import { Subscribe } from "src/commons/entities/subscribe.entity";
+import { EntityRepository, Repository } from "typeorm";
+
+@EntityRepository(Subscribe)
+export class SubscribeRepository extends Repository<Subscribe> {}

--- a/packages/server/src/subscribe/subscribe.service.ts
+++ b/packages/server/src/subscribe/subscribe.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from "@nestjs/common";
+import { Subscribe } from "src/commons/entities/subscribe.entity";
+
+import { SubscribeRepository } from "./subscribe.repository";
+
+@Injectable()
+export class SubscribeService {
+  constructor(private readonly subscribeRepository: SubscribeRepository) {}
+
+  async findByUser(userId: number): Promise<Subscribe> {
+    const subscribe = await this.subscribeRepository.findOne({
+      where: {
+        user: userId,
+      },
+      relations: [ "user", "board" ],
+    });
+    return subscribe;
+  }
+}

--- a/packages/server/src/subscribe/subscribe.service.ts
+++ b/packages/server/src/subscribe/subscribe.service.ts
@@ -16,4 +16,18 @@ export class SubscribeService {
     });
     return subscribe;
   }
+
+  async findByUserAndBoard(
+    userId: number,
+    boardId: number,
+  ): Promise<Subscribe> {
+    const subscribe = await this.subscribeRepository.findOne({
+      where: {
+        user: userId,
+        board: boardId,
+      },
+      relations: [ "user", "board" ],
+    });
+    return subscribe;
+  }
 }

--- a/packages/server/src/subscribe/subscribe.service.ts
+++ b/packages/server/src/subscribe/subscribe.service.ts
@@ -7,8 +7,8 @@ import { SubscribeRepository } from "./subscribe.repository";
 export class SubscribeService {
   constructor(private readonly subscribeRepository: SubscribeRepository) {}
 
-  async findByUser(userId: number): Promise<Subscribe> {
-    const subscribe = await this.subscribeRepository.findOne({
+  async findByUser(userId: number): Promise<Subscribe[]> {
+    const subscribe = await this.subscribeRepository.find({
       where: {
         user: userId,
       },


### PR DESCRIPTION
## 👀 이슈

resolve #291 

## 📌 개요

- user uuid를 이용, 요청 사용자가 전체 보드 계층에서 특정 보드를 구독 또는 알림 설정했는지 확인합니다.

## 👩‍💻 작업 사항

- 보드 계층 조회 API 수정
  - AuthMiddleware를 이용, 요청한 user 정보 확인
  - 보드 계층별로 해당 사용자가 구독 or 알림 설정을 했는지 확인
- 보드 계층 조회 API swagger 업데이트 
  - header에 uuid 추가 

## ✅ 참고 사항

<!-- 공유할 내용, 스크린샷 등을 넣어 주세요. -->
