### PR TITLE
[server] article 생성 API guard 이용하도록 수정

### DIFF
--- a/packages/server/src/article/article.controller.ts
+++ b/packages/server/src/article/article.controller.ts
@@ -6,12 +6,15 @@ import {
   Param,
   Post,
   Put,
+  Req,
+  UseGuards,
 } from "@nestjs/common";
-import { ApiOperation, ApiResponse, ApiTags } from "@nestjs/swagger";
+import { ApiHeader, ApiOperation, ApiResponse, ApiTags } from "@nestjs/swagger";
 import { Builder } from "builder-pattern";
 import { BoardTreeService } from "src/boardTree/boardTree.service";
 import { BoardTreeResponseDto } from "src/boardTree/dto/boardTree.response.dto";
 import { Public } from "src/commons/decorators/public.decorator";
+import { AdminAuthGuard } from "src/commons/guards/admin-auth.guard";
 
 import { ArticleService } from "./article.service";
 import { ArticleCreateDto } from "./dtos/article.create.dto";
@@ -64,7 +67,7 @@ export class ArticleController {
     return this.articleService.findArticleRes(articleId);
   }
 
-  @Post("/boards/:boardId/article/admin/:adminId")
+  @Post("/boards/:boardId/article")
   @ApiOperation({
     summary: "신규 공지사항 등록 API",
     description: "특정 공지사항 사이트에서 받아온 새로운 공지사항을 등록한다.",
@@ -73,15 +76,20 @@ export class ArticleController {
     status: 201,
     description: "생성된 article id (PK)",
   })
+  @ApiHeader({
+    name: "jwt",
+    description: "admin jwt",
+  })
+  @UseGuards(AdminAuthGuard)
   async create(
     @Param("boardId") boardId: number,
-    @Param("adminId") adminId: number,
     @Body() articleCreateDto: ArticleCreateDto,
+    @Req() req,
   ): Promise<number> {
-    console.log({ articleCreateDto });
+    const { admin } = req;
     const article = await this.articleService.create(
       boardId,
-      adminId,
+      admin.id,
       articleCreateDto,
     );
     return article.id;

--- a/packages/server/src/article/article.controller.ts
+++ b/packages/server/src/article/article.controller.ts
@@ -77,7 +77,7 @@ export class ArticleController {
     description: "생성된 article id (PK)",
   })
   @ApiHeader({
-    name: "jwt",
+    name: "x-access-token",
     description: "admin jwt",
   })
   @UseGuards(AdminAuthGuard)

--- a/packages/server/src/article/article.controller.ts
+++ b/packages/server/src/article/article.controller.ts
@@ -89,7 +89,7 @@ export class ArticleController {
     const { admin } = req;
     const article = await this.articleService.create(
       boardId,
-      admin.id,
+      admin,
       articleCreateDto,
     );
     return article.id;

--- a/packages/server/src/article/article.service.ts
+++ b/packages/server/src/article/article.service.ts
@@ -6,6 +6,7 @@ import { BoardService } from "src/board/board.service";
 import { BoardTreeService } from "src/boardTree/boardTree.service";
 import { BoardTreeResponseDto } from "src/boardTree/dto/boardTree.response.dto";
 import { BookmarkRepository } from "src/bookmark/bookmark.repository";
+import { Admin } from "src/commons/entities/admin.entity";
 import { Article } from "src/commons/entities/article.entity";
 import { Errors } from "src/commons/exception/exception.global";
 import { HitRepository } from "src/hit/hit.repository";
@@ -37,14 +38,13 @@ export class ArticleService {
   @Transactional()
   async create(
     boardId: number,
-    adminId: number,
+    admin: Admin,
     articleCreateDto: ArticleCreateDto,
   ): Promise<Article> {
     if ((await this.articleRepository.existsByUrl(articleCreateDto.url)) > 0)
       throw ARTICLE_URL_EXISTS;
 
     const board = await this.boardService.findById(boardId);
-    const admin = await this.adminService.findById(adminId);
 
     const article = Builder(Article)
       .author(admin)

--- a/packages/server/src/commons/exception/exception.global.ts
+++ b/packages/server/src/commons/exception/exception.global.ts
@@ -36,4 +36,13 @@ export const Errors = {
     "이미 구독 중인 board 입니다.",
   ),
   NOT_SUBSCRIBED_BOARD: new NotFoundException("구독 중인 board가 아닙니다."),
+
+  // image 도메인에 대한 예외 메세지
+  IMAGE_ID_NOT_FOUND: new NotFoundException(
+    "해당 id의 image가 존재하지 않습니다.",
+  ),
+
+  IMAGE_URL_NOT_FOUND: new NotFoundException(
+    "해당 url의 image가 존재하지 않습니다.",
+  ),
 };

--- a/packages/server/src/image/image.service.ts
+++ b/packages/server/src/image/image.service.ts
@@ -6,7 +6,7 @@ import { AwsService } from "./aws.service";
 import { UploadImageResponse } from "./dto/upload-image.response.dto";
 import { ImageRepository } from "./image.repository";
 
-const { NO_DATA_IN_DB } = Errors;
+const { IMAGE_ID_NOT_FOUND, IMAGE_URL_NOT_FOUND } = Errors;
 
 @Injectable()
 export class ImageService {
@@ -27,7 +27,7 @@ export class ImageService {
         id,
       },
     });
-    if (!image) throw NO_DATA_IN_DB;
+    if (!image) throw IMAGE_ID_NOT_FOUND;
     return image;
   }
 
@@ -37,7 +37,7 @@ export class ImageService {
         url,
       },
     });
-    if (!image) throw NO_DATA_IN_DB;
+    if (!image) throw IMAGE_URL_NOT_FOUND;
     return image;
   }
 }


### PR DESCRIPTION
## 👀 이슈

resolve #309 

## 📌 개요

- adminId를 직접 받는 article create API를 jwt와 guard를 이용하도록 수정합니다.

## 👩‍💻 작업 사항

- path variable에서 adminId 삭제
- admin guard를 이용, request header에서 jwt로 바로 admin 객체를 받아오도록 수정

## ✅ 참고 사항

<!-- 공유할 내용, 스크린샷 등을 넣어 주세요. -->
