### PR TITLE
[mobile] 식사 베타 아이콘 툴팁 추가건

### DIFF
--- a/packages/mobile/src/components/templates/PlaceTemplate/index.tsx
+++ b/packages/mobile/src/components/templates/PlaceTemplate/index.tsx
@@ -1,9 +1,9 @@
 import { useState } from "react";
-import { NavLink, useLocation, useNavigate } from "react-router-dom";
+import { NavLink } from "react-router-dom";
 
 import { MapArrow } from "@components/atoms/icon/MapArrow";
 import Chips from "@components/molecules/Chips";
-import { useAppDispatch, useAppSelector } from "src/store";
+import { useAppDispatch } from "src/store";
 import { setHashMenu } from "src/store/placeSlice";
 
 import {
@@ -70,6 +70,11 @@ function PlaceTemplate({ menuType }: Props) {
             );
           })}
         </div>
+      </div>
+      <div className={$.tooltip}>
+        <span className={$.tooltip_title}>
+          식사는 현재 베타버전으로, 다양한 맛집이 더 추가될 예정입니다.
+        </span>
       </div>
       <div className={$.content}>
         <Chips list={getHashList()} />

--- a/packages/mobile/src/components/templates/PlaceTemplate/index.tsx
+++ b/packages/mobile/src/components/templates/PlaceTemplate/index.tsx
@@ -3,6 +3,7 @@ import { NavLink } from "react-router-dom";
 
 import { MapArrow } from "@components/atoms/icon/MapArrow";
 import Chips from "@components/molecules/Chips";
+import BorderBox from "src/components/atoms/BorderBox";
 import { useAppDispatch } from "src/store";
 import { setHashMenu } from "src/store/placeSlice";
 
@@ -71,11 +72,11 @@ function PlaceTemplate({ menuType }: Props) {
           })}
         </div>
       </div>
-      <div className={$.tooltip}>
+      <BorderBox className={$.tooltip} style={{ width: "auto" }}>
         <span className={$.tooltip_title}>
           식사는 현재 베타버전으로, 다양한 맛집이 더 추가될 예정입니다.
         </span>
-      </div>
+      </BorderBox>
       <div className={$.content}>
         <Chips list={getHashList()} />
         <div className={$.image_list}>

--- a/packages/mobile/src/components/templates/PlaceTemplate/style.module.scss
+++ b/packages/mobile/src/components/templates/PlaceTemplate/style.module.scss
@@ -93,8 +93,9 @@
 
 .tooltip {
   margin: 186px 8px 0;
+  border-radius: 4px;
   background-color: $white;
-  padding: 7px 13px 6px 18px;
+  padding: 7px 21px 6px;
 
   & + .content {
     .image_list {

--- a/packages/mobile/src/components/templates/PlaceTemplate/style.module.scss
+++ b/packages/mobile/src/components/templates/PlaceTemplate/style.module.scss
@@ -95,7 +95,7 @@
   margin: 186px 8px 0;
   border-radius: 4px;
   background-color: $white;
-  padding: 7px 21px 6px;
+  padding: 7px 21px;
 
   & + .content {
     .image_list {

--- a/packages/mobile/src/components/templates/PlaceTemplate/style.module.scss
+++ b/packages/mobile/src/components/templates/PlaceTemplate/style.module.scss
@@ -91,6 +91,24 @@
   background-color: $background;
 }
 
+.tooltip {
+  margin: 186px 8px 0;
+  background-color: $white;
+  padding: 7px 13px 6px 18px;
+
+  & + .content {
+    .image_list {
+      margin-top: 0;
+    }
+  }
+
+  .tooltip_title {
+    font-size: 12px;
+    line-height: 20px;
+    color: $black-60;
+  }
+}
+
 .image_list {
   margin-top: 180px;
 }


### PR DESCRIPTION
## 👀 이슈
resolve #326 

## 📌 개요
- 식사 베타 아이콘 툴팁을 추가하였습니다.

## 👩‍💻 작업 사항
- 디자인 가이드에 맞춰서 식사 베타 아이콘 툴팁을 추가하였습니다.

## ✅ 참고 사항
- https://www.figma.com/file/fCzuV7VJDKWY9N6J89XKV0/%EC%B6%A9%EB%A6%BC%EC%9D%B4?node-id=3680%3A502
<img width="372" alt="스크린샷 2022-07-24 오후 5 39 38" src="https://user-images.githubusercontent.com/22065725/180639338-525523d0-2db4-478c-9c62-311a3476895e.png">

