### PR TITLE
[server] 유저 정보 저장 로직 및 FCM PUSH 알람 연결

### DIFF
--- a/packages/server/src/article/article.module.ts
+++ b/packages/server/src/article/article.module.ts
@@ -15,6 +15,8 @@ import { ImageService } from "src/image/image.service";
 import { SubscribeRepository } from "src/subscribe/subscribe.repository";
 import { SubscribeService } from "src/subscribe/subscribe.service";
 
+import { FcmService } from "../fcm/fcm.service";
+import { UserRepository } from "../user/repository/user.repository";
 import { ArticleController } from "./article.controller";
 import { ArticleRepository } from "./article.repository";
 import { ArticleService } from "./article.service";
@@ -30,6 +32,7 @@ import { ArticleService } from "./article.service";
       ArticleImageRepository,
       ImageRepository,
       SubscribeRepository,
+      UserRepository,
     ]),
     AdminModule,
   ],
@@ -42,6 +45,7 @@ import { ArticleService } from "./article.service";
     ArticleImageService,
     SubscribeService,
     ImageService,
+    FcmService,
   ],
 })
 export class ArticleModule {}

--- a/packages/server/src/article/article.service.ts
+++ b/packages/server/src/article/article.service.ts
@@ -16,6 +16,7 @@ import { ImageService } from "src/image/image.service";
 import { SubscribeService } from "src/subscribe/subscribe.service";
 import { Transactional } from "typeorm-transactional-cls-hooked";
 
+import { FcmService } from "../fcm/fcm.service";
 import { ArticleRepository } from "./article.repository";
 import { ArticleCreateDto } from "./dtos/article.create.dto";
 import {
@@ -40,6 +41,7 @@ export class ArticleService {
     private readonly subscribeService: SubscribeService,
     private readonly articleImageService: ArticleImageService,
     private readonly imageService: ImageService,
+    private readonly fcmService: FcmService,
   ) {}
 
   @Transactional()
@@ -72,6 +74,8 @@ export class ArticleService {
         await this.articleImageService.create(image, article);
       }),
     );
+
+    await this.fcmService.sendNotices(boardId);
 
     return result;
   }

--- a/packages/server/src/commons/entities/user.entity.ts
+++ b/packages/server/src/commons/entities/user.entity.ts
@@ -2,6 +2,11 @@ import { Column, Entity } from "typeorm";
 
 import { CommonEntity } from "./common.entity";
 
+export enum Device {
+  IOS = "ios",
+  ANDROID = "android",
+}
+
 @Entity("user")
 export class User extends CommonEntity {
   @Column("uuid", { unique: true, nullable: false })
@@ -9,4 +14,7 @@ export class User extends CommonEntity {
 
   @Column("varchar", { unique: true, nullable: false })
   fcmToken: string;
+
+  @Column("enum", { enum: Device, nullable: true })
+  device: Device;
 }

--- a/packages/server/src/commons/entities/user.entity.ts
+++ b/packages/server/src/commons/entities/user.entity.ts
@@ -15,6 +15,6 @@ export class User extends CommonEntity {
   @Column("varchar", { unique: true, nullable: false })
   fcmToken: string;
 
-  @Column("enum", { enum: Device, nullable: true })
+  @Column("enum", { enum: Device, nullable: false })
   device: Device;
 }

--- a/packages/server/src/commons/middlewares/auth.middleware.ts
+++ b/packages/server/src/commons/middlewares/auth.middleware.ts
@@ -24,10 +24,17 @@ export class AuthMiddleware implements NestMiddleware {
     }
 
     if (userUuid) {
-      const user = await this.userService.findOne({
+      let user = await this.userService.findOne({
         where: { uuid: req.headers.uuid },
       });
 
+      if (!user) {
+        user = await this.userService.create({
+          uuid: userUuid,
+          fcmToken: req.headers.fcmtoken,
+          device: req.headers.device,
+        });
+      }
       req.user = user;
     }
 

--- a/packages/server/src/commons/middlewares/auth.middleware.ts
+++ b/packages/server/src/commons/middlewares/auth.middleware.ts
@@ -27,7 +27,7 @@ export class AuthMiddleware implements NestMiddleware {
       let user = await this.userService.findOne({
         where: { uuid: req.headers.uuid },
       });
-
+ 
       if (!user) {
         user = await this.userService.create({
           uuid: userUuid,

--- a/packages/server/src/fcm/fcm.module.ts
+++ b/packages/server/src/fcm/fcm.module.ts
@@ -1,8 +1,21 @@
 import { Module } from "@nestjs/common";
+import { TypeOrmModule } from "@nestjs/typeorm";
 
+import { BookmarkRepository } from "../bookmark/bookmark.repository";
+import { HitRepository } from "../hit/hit.repository";
+import { SubscribeRepository } from "../subscribe/subscribe.repository";
+import { UserRepository } from "../user/repository/user.repository";
 import { FcmService } from "./fcm.service";
 
 @Module({
+  imports: [
+    TypeOrmModule.forFeature([
+      SubscribeRepository,
+      UserRepository,
+      BookmarkRepository,
+      HitRepository,
+    ]),
+  ],
   providers: [ FcmService ],
   exports: [ FcmService ],
 })

--- a/packages/server/src/fcm/fcm.service.ts
+++ b/packages/server/src/fcm/fcm.service.ts
@@ -3,9 +3,7 @@ import { ConfigService } from "@nestjs/config";
 import * as FCM from "fcm-node";
 import { isNil } from "lodash";
 
-import { BookmarkRepository } from "../bookmark/bookmark.repository";
 import { Device } from "../commons/entities/user.entity";
-import { HitRepository } from "../hit/hit.repository";
 import { SubscribeRepository } from "../subscribe/subscribe.repository";
 import { UserRepository } from "../user/repository/user.repository";
 import { Data } from "./fcm.interfaces";
@@ -14,16 +12,18 @@ import { Data } from "./fcm.interfaces";
 export class FcmService {
   private readonly serverKey;
   private readonly fcm;
+  private readonly collapseKeyAndroid;
+  private readonly collapseKeyIos;
 
   constructor(
     private readonly configService: ConfigService,
     private readonly subscribeRepository: SubscribeRepository,
     private readonly userRepository: UserRepository,
-    private readonly bookmarkRepository: BookmarkRepository,
-    private readonly hitRepository: HitRepository,
   ) {
     this.serverKey = this.configService.get("fcm").serverKey;
     this.fcm = new FCM(this.serverKey);
+    this.collapseKeyAndroid = this.configService.get("fcm").collapseKeyAndroid;
+    this.collapseKeyIos = this.configService.get("fcm").collapseKeyIos;
   }
 
   private static message(to: string, data: Data, collapseKey: string) {
@@ -63,9 +63,9 @@ export class FcmService {
       const { fcmToken } = user;
 
       if (user.device === Device.ANDROID) {
-        this.sendNotice(fcmToken, data, "com.jaryapp.myapplication3");
+        this.sendNotice(fcmToken, data, this.collapseKeyAndroid);
       } else if (user.device === Device.IOS) {
-        this.sendNotice(fcmToken, data, "com.cmi.cbnu-alrami");
+        this.sendNotice(fcmToken, data, this.collapseKeyIos);
       }
     });
   }

--- a/packages/server/src/fcm/fcm.service.ts
+++ b/packages/server/src/fcm/fcm.service.ts
@@ -1,79 +1,92 @@
-import {
-  BadRequestException,
-  Injectable,
-  InternalServerErrorException,
-} from "@nestjs/common";
+import { BadRequestException, Injectable } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import * as FCM from "fcm-node";
 import { isNil } from "lodash";
 
+import { BookmarkRepository } from "../bookmark/bookmark.repository";
+import { Device } from "../commons/entities/user.entity";
+import { HitRepository } from "../hit/hit.repository";
+import { SubscribeRepository } from "../subscribe/subscribe.repository";
+import { UserRepository } from "../user/repository/user.repository";
 import { Data } from "./fcm.interfaces";
 
 @Injectable()
 export class FcmService {
   private readonly serverKey;
   private readonly fcm;
-  constructor(private readonly configService: ConfigService) {
+
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly subscribeRepository: SubscribeRepository,
+    private readonly userRepository: UserRepository,
+    private readonly bookmarkRepository: BookmarkRepository,
+    private readonly hitRepository: HitRepository,
+  ) {
     this.serverKey = this.configService.get("fcm").serverKey;
     this.fcm = new FCM(this.serverKey);
   }
 
   private static message(to: string, data: Data, collapseKey: string) {
-    try {
-      const { title, body } = data;
+    const { title, body } = data;
 
-      if (isNil(title) || isNil(body)) {
-        throw new BadRequestException("Is empty!");
+    if (isNil(title) || isNil(body)) {
+      throw new BadRequestException("Is empty!");
+    }
+
+    return {
+      to,
+      collapse_key: collapseKey,
+      notification: {
+        title: data.title,
+        body: data.body,
+        click_action: "Result3Activity",
+      },
+      data,
+    };
+  }
+
+  public async sendNotices(boardId: number): Promise<void> {
+    const subscribes = await this.subscribeRepository.findUserByBoard(boardId);
+
+    if (subscribes.length === 0) {
+      return;
+    }
+
+    const userIds = subscribes.map((subscribe) => {
+      return subscribe.user.id;
+    });
+
+    const users = await this.userRepository.findUserById(userIds);
+
+    users.forEach((user) => {
+      const data = { title: "CMI", body: "공지사항 등록" };
+      const { fcmToken } = user;
+
+      if (user.device === Device.ANDROID) {
+        this.sendNotice(fcmToken, data, "com.jaryapp.myapplication3");
+      } else if (user.device === Device.IOS) {
+        this.sendNotice(fcmToken, data, "com.cmi.cbnu-alrami");
       }
-
-      return {
-        to,
-        collapse_key: collapseKey,
-        notification: {
-          title: data.title,
-          body: data.body,
-          click_action: "Result3Activity",
-        },
-        data,
-      };
-    } catch (err) {
-      throw new InternalServerErrorException("Server error");
-    }
+    });
   }
 
-  public sendNoticeAndroid(to: string, data: Data) {
-    try {
-      this.fcm.send(
-        FcmService.message(to, data, "com.jaryapp.myapplication3"),
-        (err, res) => {
-          if (err) {
-            console.log(err);
-            console.log("Something has gone wrong!");
-          } else {
-            console.log("Successfully sent with response: ", res);
+  private async sendNotice(
+    to: string,
+    data: Data,
+    collapseKey: string,
+  ): Promise<void> {
+    await this.fcm.send(
+      FcmService.message(to, data, collapseKey),
+      async (err, res) => {
+        if (err) {
+          if (JSON.parse(err).results[0].error === "InvalidRegistration") {
+            await this.userRepository.delete({ fcmToken: to });
           }
-        },
-      );
-    } catch (err) {
-      throw new InternalServerErrorException("Server error");
-    }
-  }
-
-  public sendNoticeIos(to: string, data: Data) {
-    try {
-      this.fcm.send(
-        FcmService.message(to, data, "com.cmi.cbnu-alrami"),
-        (err, res) => {
-          if (err) {
-            console.log(err);
-            console.log("Something has gone wrong!");
-          } else {
-            console.log("Successfully sent with response: ", res);
-          }
-        },
-      );
-    } catch (err) {
-      throw new InternalServerErrorException("Server error");
-    }
+          throw new BadRequestException(err);
+        } else {
+          console.log("Successfully sent with response: ", res);
+        }
+      },
+    );
   }
 }

--- a/packages/server/src/subscribe/subscribe.repository.ts
+++ b/packages/server/src/subscribe/subscribe.repository.ts
@@ -15,4 +15,12 @@ export class SubscribeRepository extends Repository<Subscribe> {
       .select([ "board_id AS boardId" ])
       .getRawMany();
   }
+
+  async findUserByBoard(boardId: number) {
+    return this.createQueryBuilder("subscribe")
+      .leftJoinAndSelect("subscribe.user", "user")
+      .where("subscribe.board_id = :boardId", { boardId })
+      .andWhere("subscribe.notice = :state", { state: true })
+      .getMany();
+  }
 }

--- a/packages/server/src/user/dto/userCreate.dto.ts
+++ b/packages/server/src/user/dto/userCreate.dto.ts
@@ -1,4 +1,6 @@
-import { IsNotEmpty, IsString } from "class-validator";
+import { IsEnum, IsNotEmpty, IsOptional, IsString } from "class-validator";
+
+import { Device } from "../../commons/entities/user.entity";
 
 export class UserCreateDto {
   @IsNotEmpty()
@@ -8,4 +10,8 @@ export class UserCreateDto {
   @IsNotEmpty()
   @IsString()
   fcmToken: string;
+
+  @IsOptional()
+  @IsEnum(Device)
+  device: Device;
 }

--- a/packages/server/src/user/repository/user.repository.ts
+++ b/packages/server/src/user/repository/user.repository.ts
@@ -2,4 +2,12 @@ import { User } from "src/commons/entities/user.entity";
 import { EntityRepository, Repository } from "typeorm";
 
 @EntityRepository(User)
-export class UserRepository extends Repository<User> {}
+export class UserRepository extends Repository<User> {
+  async findUserById(userIds: number[]) {
+    return this.createQueryBuilder("user")
+      .where("user.id IN (:userIds)", {
+        userIds,
+      })
+      .getMany();
+  }
+}

--- a/packages/server/src/user/user.service.ts
+++ b/packages/server/src/user/user.service.ts
@@ -24,7 +24,6 @@ export class UserService {
 
   async findOne(query: FindOneOptions<User>): Promise<User> {
     const user = await this.userRepository.findOne(query);
-    if (!user) throw USER_NOT_FOUND;
     return user;
   }
 
@@ -35,8 +34,9 @@ export class UserService {
 
   async create(userCreateDto: UserCreateDto): Promise<User> {
     const createdUser = await this.userRepository.create(userCreateDto);
-    if (!createdUser) throw DB_ERROR;
-    return createdUser;
+    const user = await this.userRepository.save(createdUser);
+    if (!user) throw DB_ERROR;
+    return user;
   }
 
   async delete(query: FindConditions<User>): Promise<DeleteResult> {


### PR DESCRIPTION
## 👀 이슈

resolve #

## 📌 개요

유저 정보를 저장 로직과 FCM PUSH 알람을 연결합니다.

## 👩‍💻 작업 사항

유저가 처음 App에 진입하게 되면 유저의 uuid, fcm-token, device 정보를 auth-middleware에서 저장합니다.
게시글이 등록되면 해당 게시글을 구독, 알람 설정한 유저에게 FCM PUSH 알람을 보냅니다. 유효하지 않은 fcm-token이라면 해당 유저를 삭제합니다. 이 때에는 해당 유저와 관련된 구독(subscribe), 조회(hit), 북마크(bookmark) 데이터도 함께 삭제합니다. 

## ✅ 참고 사항

<!-- 공유할 내용, 스크린샷 등을 넣어 주세요. -->
