### PR TITLE
[server] 유저가 구독 & 알림을 받는 게시판 목록 조회 API 개발

### DIFF
--- a/packages/server/src/boardTree/boardTree.service.ts
+++ b/packages/server/src/boardTree/boardTree.service.ts
@@ -3,14 +3,11 @@ import { Builder } from "builder-pattern";
 import { BoardResponseDto } from "src/board/dto/board.response.dto";
 import { BoardTree } from "src/commons/entities/boardTree.entity";
 import { Subscribe } from "src/commons/entities/subscribe.entity";
-import { Errors } from "src/commons/exception/exception.global";
 import { SubscribeService } from "src/subscribe/subscribe.service";
 
 import { BoardTreeRepository } from "./boardTree.repository";
 import { BoardTreeAllResponseDto } from "./dto/boardTree.all.response.dto";
 import { BoardTreeResponseDto } from "./dto/boardTree.response.dto";
-
-const { BOARD_ID_NOT_FOUND } = Errors;
 
 @Injectable()
 export class BoardTreeService {

--- a/packages/server/src/subscribe/dtos/subscribe.dto.ts
+++ b/packages/server/src/subscribe/dtos/subscribe.dto.ts
@@ -1,0 +1,8 @@
+export class SubscribeNoticeDto {
+  id: number;
+  isNoticing: boolean;
+}
+
+export class SubscribeInfoDto extends SubscribeNoticeDto {
+  name: string;
+}

--- a/packages/server/src/subscribe/subscribe.controller.ts
+++ b/packages/server/src/subscribe/subscribe.controller.ts
@@ -18,7 +18,7 @@ import { SubscribeService } from "./subscribe.service";
 @Public()
 @Controller()
 @ApiTags("[subscribe] 공지사항 사이트 구독 관련 API")
-export class SubscribeControlelr {
+export class SubscribeController {
   constructor(private readonly subscribeService: SubscribeService) {}
 
   @Post("subscribe/boards/:boardId")
@@ -113,6 +113,6 @@ export class SubscribeControlelr {
   })
   @UseGuards(UserAuthGuard)
   async findAllSubscribeAndNotice(@UserSession() user: User) {
-    console.log({ user });
+    return this.subscribeService.findAllSubscribeAndNotice(user);
   }
 }

--- a/packages/server/src/subscribe/subscribe.controller.ts
+++ b/packages/server/src/subscribe/subscribe.controller.ts
@@ -1,6 +1,7 @@
 import {
   Controller,
   Delete,
+  Get,
   Param,
   Post,
   Req,
@@ -8,6 +9,8 @@ import {
 } from "@nestjs/common";
 import { ApiHeader, ApiOperation, ApiResponse, ApiTags } from "@nestjs/swagger";
 import { Public } from "src/commons/decorators/public.decorator";
+import { UserSession } from "src/commons/decorators/UserSession.decorator";
+import { User } from "src/commons/entities/user.entity";
 import { UserAuthGuard } from "src/commons/guards/user-auth.guard";
 
 import { SubscribeService } from "./subscribe.service";
@@ -92,5 +95,24 @@ export class SubscribeControlelr {
   async deleteNotice(@Req() req, @Param("boardId") boardId: number) {
     const { user } = req;
     return this.subscribeService.updateNotice(user, boardId, false);
+  }
+
+  @Get("subscribe/boards/info")
+  @ApiOperation({
+    summary: "공지사항 사이트 구독 & 알림 정보 조회 API",
+    description:
+      "로그인 한 유저가 구독 & 알림 설정한 공지사항 사이트 리스트를 조회합니다.",
+  })
+  @ApiResponse({
+    status: 200,
+    description: "성공 여부",
+  })
+  @ApiHeader({
+    name: "uuid",
+    description: "user uuid",
+  })
+  @UseGuards(UserAuthGuard)
+  async findAllSubscribeAndNotice(@UserSession() user: User) {
+    console.log({ user });
   }
 }

--- a/packages/server/src/subscribe/subscribe.module.ts
+++ b/packages/server/src/subscribe/subscribe.module.ts
@@ -2,14 +2,21 @@ import { Module } from "@nestjs/common";
 import { TypeOrmModule } from "@nestjs/typeorm";
 import { BoardRepository } from "src/board/board.repository";
 import { BoardService } from "src/board/board.service";
+import { BoardTreeRepository } from "src/boardTree/boardTree.repository";
 
-import { SubscribeControlelr } from "./subscribe.controller";
+import { SubscribeController } from "./subscribe.controller";
 import { SubscribeRepository } from "./subscribe.repository";
 import { SubscribeService } from "./subscribe.service";
 
 @Module({
-  imports: [ TypeOrmModule.forFeature([ BoardRepository, SubscribeRepository ]) ],
-  controllers: [ SubscribeControlelr ],
+  imports: [
+    TypeOrmModule.forFeature([
+      BoardRepository,
+      SubscribeRepository,
+      BoardTreeRepository,
+    ]),
+  ],
+  controllers: [ SubscribeController ],
   providers: [ BoardService, SubscribeService ],
 })
 export class SubscribeModule {}

--- a/packages/server/src/subscribe/subscribe.service.ts
+++ b/packages/server/src/subscribe/subscribe.service.ts
@@ -1,10 +1,14 @@
 import { Injectable } from "@nestjs/common";
 import { Builder } from "builder-pattern";
 import { BoardService } from "src/board/board.service";
+import { BoardTreeRepository } from "src/boardTree/boardTree.repository";
+import { Board } from "src/commons/entities/board.entity";
+import { BoardTree } from "src/commons/entities/boardTree.entity";
 import { Subscribe } from "src/commons/entities/subscribe.entity";
 import { User } from "src/commons/entities/user.entity";
 import { Errors } from "src/commons/exception/exception.global";
 
+import { SubscribeInfoDto } from "./dtos/subscribe.dto";
 import { SubscribeRepository } from "./subscribe.repository";
 
 const { ALREADY_SUBSCRIBE_BOARD, NOT_SUBSCRIBED_BOARD } = Errors;
@@ -13,6 +17,7 @@ const { ALREADY_SUBSCRIBE_BOARD, NOT_SUBSCRIBED_BOARD } = Errors;
 export class SubscribeService {
   constructor(
     private readonly subscribeRepository: SubscribeRepository,
+    private readonly boardTreeRepository: BoardTreeRepository,
     private readonly boardService: BoardService,
   ) {}
 
@@ -78,6 +83,7 @@ export class SubscribeService {
     return subscribe;
   }
 
+  // DESCRIBE: 알림 설정 on / off
   async updateNotice(user: User, boardId: number, ableFlag: boolean) {
     const board = await this.boardService.findById(boardId);
     const subscribeInfo: Subscribe = await this.findByUserAndBoard(
@@ -92,5 +98,39 @@ export class SubscribeService {
       await this.subscribeRepository.save(subscribeInfo);
     }
     return "success";
+  }
+
+  async findAllSubscribeAndNotice(user: User): Promise<SubscribeInfoDto[]> {
+    let response = [];
+    const subscribes = await this.findByUser(user.id);
+    response = await Promise.all(
+      subscribes.map(async (subscribe) => {
+        const boardTreeName = await this.getBoardTreeName(subscribe.board);
+        return Builder(SubscribeInfoDto)
+          .id(subscribe.id)
+          .name(boardTreeName)
+          .isNoticing(subscribe.notice)
+          .build();
+      }),
+    );
+    return response;
+  }
+
+  async getBoardTreeName(board: Board): Promise<string> {
+    let response = board.name;
+    const boardId = board.id;
+    const boardTree: BoardTree = await this.boardTreeRepository.findOne({
+      where: {
+        board: boardId,
+      },
+      relations: [ "board", "parentBoard" ],
+    });
+    if (typeof boardTree !== "undefined" && boardTree.parentBoard !== null) {
+      const { parentBoard } = boardTree;
+      const parentName = await this.getBoardTreeName(parentBoard);
+      response = `${parentName} > ${response}`;
+    }
+
+    return response;
   }
 }


### PR DESCRIPTION
## 👀 이슈

resolve #353 

## 📌 개요

- 유저가 구독 & 알림 신청을 받는 게시판 확인이 필요합니다.

## 👩‍💻 작업 사항

- 현재 로그인 한 유저가 구독 신청을 한 & 알림 신청을 한 게시판 목록을 조회하는 API를 개발합니다.

## ✅ 참고 사항

<!-- 공유할 내용, 스크린샷 등을 넣어 주세요. -->
