### PR TITLE
[server] article 수정 API에 image 수정 로직 추가

### DIFF
--- a/packages/server/src/article/article.controller.ts
+++ b/packages/server/src/article/article.controller.ts
@@ -100,7 +100,7 @@ export class ArticleController {
     return article.id;
   }
 
-  @Put("/article/:articleId")
+  @Put("/articles/:articleId")
   @ApiOperation({
     summary: "특정 공지사항 정보 수정 API",
     description: "공지사항 id(pk)를 이용, 해당 공지사항의 정보를 수정한다.",

--- a/packages/server/src/article/article.controller.ts
+++ b/packages/server/src/article/article.controller.ts
@@ -7,14 +7,16 @@ import {
   Post,
   Put,
   Req,
-  UseGuards
+  UseGuards,
 } from "@nestjs/common";
 import { ApiHeader, ApiOperation, ApiResponse, ApiTags } from "@nestjs/swagger";
 import { Builder } from "builder-pattern";
 import { BoardTreeService } from "src/boardTree/boardTree.service";
 import { BoardTreeResponseDto } from "src/boardTree/dto/boardTree.response.dto";
+import { AdminSession } from "src/commons/decorators/AdminSession.decorator";
 import { Public } from "src/commons/decorators/public.decorator";
 import { UserSession } from "src/commons/decorators/UserSession.decorator";
+import { Admin } from "src/commons/entities/admin.entity";
 import { User } from "src/commons/entities/user.entity";
 import { AdminAuthGuard } from "src/commons/guards/admin-auth.guard";
 
@@ -110,11 +112,17 @@ export class ArticleController {
     description: "수정된 공지사항 정보",
     type: ArticleDto,
   })
+  @ApiHeader({
+    name: "x-access-token",
+    description: "admin jwt",
+  })
   async update(
+    @AdminSession() admin: Admin,
     @Param("articleId") articleId: number,
     @Body() articleUpdateDto: ArticleUpdateDto,
   ): Promise<ArticleDto> {
     const article = await this.articleService.update(
+      admin,
       articleId,
       articleUpdateDto,
     );

--- a/packages/server/src/article/article.controller.ts
+++ b/packages/server/src/article/article.controller.ts
@@ -6,7 +6,6 @@ import {
   Param,
   Post,
   Put,
-  Req,
   UseGuards,
 } from "@nestjs/common";
 import { ApiHeader, ApiOperation, ApiResponse, ApiTags } from "@nestjs/swagger";
@@ -91,9 +90,8 @@ export class ArticleController {
   async create(
     @Param("boardId") boardId: number,
     @Body() articleCreateDto: ArticleCreateDto,
-    @Req() req,
+    @AdminSession() admin: Admin,
   ): Promise<number> {
-    const { admin } = req;
     const article = await this.articleService.create(
       boardId,
       admin,

--- a/packages/server/src/article/article.service.ts
+++ b/packages/server/src/article/article.service.ts
@@ -223,9 +223,7 @@ export class ArticleService {
 
     // DESCRIBE: article image 수정 요청이 있는 경우만 진행
     const newImages: number[] = articleUpdateDto.images;
-    if (Array.isArray(newImages)) {
-      await this.articleImageService.update(newImages, newArticle);
-    }
+    await this.articleImageService.update(newImages, newArticle);
     return result;
   }
 

--- a/packages/server/src/article/article.service.ts
+++ b/packages/server/src/article/article.service.ts
@@ -195,10 +195,11 @@ export class ArticleService {
     const { url } = beforeArticle;
     let { board } = beforeArticle;
 
-    // DESCRIBE: 신규 값
+    // DESCRIBE: 신규 url 값 -> 기존 Url과 다르고, 비어있지 않을 경우에만 중복 확인
     const newUrl: string = articleUpdateDto.url;
     if (
       url !== newUrl &&
+      !(await this.isEmpty(newUrl)) &&
       (await this.articleRepository.existsByUrl(newUrl)) > 0
     )
       throw ARTICLE_URL_EXISTS;

--- a/packages/server/src/article/article.service.ts
+++ b/packages/server/src/article/article.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from "@nestjs/common";
 import { Builder } from "builder-pattern";
 import * as moment from "moment-timezone";
-import { AdminService } from "src/admin/admin.service";
 import { ArticleImageService } from "src/articleImage/articleImage.service";
 import { BoardService } from "src/board/board.service";
 import { BoardTreeService } from "src/boardTree/boardTree.service";
@@ -34,7 +33,6 @@ export class ArticleService {
     private readonly articleRepository: ArticleRepository,
     private readonly bookmarkRepository: BookmarkRepository,
     private readonly hitRepository: HitRepository,
-    private readonly adminService: AdminService,
     private readonly boardService: BoardService,
     private readonly boardTreeService: BoardTreeService,
     private readonly subscribeService: SubscribeService,
@@ -226,25 +224,7 @@ export class ArticleService {
     // DESCRIBE: article image 수정 요청이 있는 경우만 진행
     const newImages: number[] = articleUpdateDto.images;
     if (Array.isArray(newImages) && newImages.length > 0) {
-      // DESCRIBE: article_image 수정
-      const beforeImages = await this.articleImageService.findImageByArticle(
-        articleId,
-      );
-
-      // DESCRIBE: 기존 이미지 차집합은 삭제
-      const beforeDiff = beforeImages.filter((x) => !newImages.includes(x));
-      const removes = beforeDiff.map(async (imageId) => {
-        await this.articleImageService.remove(imageId);
-      });
-      await Promise.all(removes);
-
-      // DESCRIBE: 신규 이미지 차집합은 새로 등록
-      const newDiff = newImages.filter((x) => !beforeImages.includes(x));
-      const updates = newDiff.map(async (imageId) => {
-        const image = await this.imageService.findById(imageId);
-        await this.articleImageService.create(image, newArticle);
-      });
-      await Promise.all(updates);
+      await this.articleImageService.update(newImages, newArticle);
     }
     return result;
   }

--- a/packages/server/src/article/article.service.ts
+++ b/packages/server/src/article/article.service.ts
@@ -223,7 +223,7 @@ export class ArticleService {
 
     // DESCRIBE: article image 수정 요청이 있는 경우만 진행
     const newImages: number[] = articleUpdateDto.images;
-    if (Array.isArray(newImages) && newImages.length > 0) {
+    if (Array.isArray(newImages)) {
       await this.articleImageService.update(newImages, newArticle);
     }
     return result;

--- a/packages/server/src/article/article.service.ts
+++ b/packages/server/src/article/article.service.ts
@@ -185,6 +185,7 @@ export class ArticleService {
   }
 
   async update(
+    admin: Admin,
     articleId: number,
     articleUpdateDto: ArticleUpdateDto,
   ): Promise<Article> {
@@ -192,7 +193,7 @@ export class ArticleService {
 
     // DESCRIBE: 이전 값
     const { url } = beforeArticle;
-    let { board, author } = beforeArticle;
+    let { board } = beforeArticle;
 
     // DESCRIBE: 신규 값
     const newUrl: string = articleUpdateDto.url;
@@ -206,15 +207,11 @@ export class ArticleService {
       board = await this.boardService.findById(articleUpdateDto.boardId);
     }
 
-    if (beforeArticle.author.id !== articleUpdateDto.adminId) {
-      author = await this.adminService.findById(articleUpdateDto.adminId);
-    }
-
     const newArticle = Object.assign(
       beforeArticle,
       Builder(Article)
         .board(board)
-        .author(author)
+        .author(admin)
         .title(articleUpdateDto.title)
         .content(articleUpdateDto.content)
         .url(articleUpdateDto.url)

--- a/packages/server/src/article/dtos/article.update.dto.ts
+++ b/packages/server/src/article/dtos/article.update.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { IsNotEmpty, IsNumber, IsString } from "class-validator";
+import { IsNotEmpty, IsNumber, IsOptional, IsString } from "class-validator";
 
 export class ArticleUpdateDto {
   @IsNotEmpty()
@@ -17,10 +17,10 @@ export class ArticleUpdateDto {
   @ApiProperty({ description: "공지사항 내용" })
   content!: string;
 
-  @IsNotEmpty()
+  @IsOptional()
   @IsString()
   @ApiProperty({ description: "공지사항 url" })
-  url!: string;
+  url: string;
 
   @IsNotEmpty()
   @ApiProperty({ description: "공지사항 등록 날짜 : YYYY-MM-DD" })

--- a/packages/server/src/article/dtos/article.update.dto.ts
+++ b/packages/server/src/article/dtos/article.update.dto.ts
@@ -1,5 +1,11 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { IsNotEmpty, IsNumber, IsOptional, IsString } from "class-validator";
+import {
+  IsArray,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+} from "class-validator";
 
 export class ArticleUpdateDto {
   @IsNotEmpty()
@@ -26,7 +32,7 @@ export class ArticleUpdateDto {
   @ApiProperty({ description: "공지사항 등록 날짜 : YYYY-MM-DD" })
   date!: Date;
 
-  @IsNotEmpty()
+  @IsArray()
   @ApiProperty({ description: "공지사항에 첨부된 이미지 id 배열" })
   images: number[];
 }

--- a/packages/server/src/article/dtos/article.update.dto.ts
+++ b/packages/server/src/article/dtos/article.update.dto.ts
@@ -1,16 +1,11 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { IsNotEmpty, IsString, IsNumber } from "class-validator";
+import { IsNotEmpty, IsNumber, IsString } from "class-validator";
 
 export class ArticleUpdateDto {
   @IsNotEmpty()
   @IsNumber()
   @ApiProperty({ description: "소속 공지사항 사이트 id (pk)" })
   boardId!: number;
-
-  @IsNotEmpty()
-  @IsNumber()
-  @ApiProperty({ description: "작성자 id (pk)" })
-  adminId!: number;
 
   @IsNotEmpty()
   @IsString()
@@ -30,4 +25,8 @@ export class ArticleUpdateDto {
   @IsNotEmpty()
   @ApiProperty({ description: "공지사항 등록 날짜 : YYYY-MM-DD" })
   date!: Date;
+
+  @IsNotEmpty()
+  @ApiProperty({ description: "공지사항에 첨부된 이미지 id 배열" })
+  images: number[];
 }

--- a/packages/server/src/articleImage/articleImage.repository.ts
+++ b/packages/server/src/articleImage/articleImage.repository.ts
@@ -13,4 +13,19 @@ export class ArticleImageRepository extends Repository<ArticleImage> {
       .where("article_image.image_id = :imageId", { imageId })
       .execute();
   }
+
+  async findImageIdByArticle(articleId: number) {
+    return this.createQueryBuilder()
+      .select([ "image_id AS imageId" ])
+      .where("article_id = :articleId", { articleId })
+      .getRawMany();
+  }
+
+  async deleteByImage(imageId: number) {
+    return this.createQueryBuilder()
+      .delete()
+      .from(ArticleImage)
+      .where("image_id = :imageId", { imageId })
+      .execute();
+  }
 }

--- a/packages/server/src/articleImage/articleImage.repository.ts
+++ b/packages/server/src/articleImage/articleImage.repository.ts
@@ -13,4 +13,10 @@ export class ArticleImageRepository extends Repository<ArticleImage> {
       .where("article_image.image_id = :imageId", { imageId })
       .execute();
   }
+
+  async findImageIdByArticle(articleId: number) {
+    return this.createQueryBuilder()
+      .select([ "image_id AS imageId" ])
+      .getRawMany();
+  }
 }

--- a/packages/server/src/articleImage/articleImage.repository.ts
+++ b/packages/server/src/articleImage/articleImage.repository.ts
@@ -13,10 +13,4 @@ export class ArticleImageRepository extends Repository<ArticleImage> {
       .where("article_image.image_id = :imageId", { imageId })
       .execute();
   }
-
-  async findImageIdByArticle(articleId: number) {
-    return this.createQueryBuilder()
-      .select([ "image_id AS imageId" ])
-      .getRawMany();
-  }
 }

--- a/packages/server/src/articleImage/articleImage.service.ts
+++ b/packages/server/src/articleImage/articleImage.service.ts
@@ -4,6 +4,7 @@ import { Article } from "src/commons/entities/article.entity";
 import { ArticleImage } from "src/commons/entities/articleImage.entity";
 import { Image } from "src/commons/entities/image.entity";
 import { Errors } from "src/commons/exception/exception.global";
+import { ImageService } from "src/image/image.service";
 
 import { ArticleImageRepository } from "./articleImage.repository";
 
@@ -13,6 +14,7 @@ const { NO_DATA_IN_DB } = Errors;
 export class ArticleImageService {
   constructor(
     private readonly articleImageRepository: ArticleImageRepository,
+    private readonly imageService: ImageService,
   ) {}
 
   async create(image: Image, article: Article) {
@@ -28,10 +30,35 @@ export class ArticleImageService {
     await this.articleImageRepository.delete({ id });
   }
 
-  async findImageByArticle(articleId: number): Promise<number[]> {
-    const articleImages =
-      await this.articleImageRepository.findImageIdByArticle(articleId);
-    const result = articleImages.map(({ articleId }) => articleId);
-    return result;
+  async findImageByArticle(articleId: number): Promise<ArticleImage[]> {
+    const articleImages = await this.articleImageRepository.find({
+      where: { article: articleId },
+      relations: [ "article", "image" ],
+    });
+    return articleImages;
+  }
+
+  async update(newImages: number[], article: Article) {
+    // DESCRIBE: article_image 수정
+    const beforeImages = await this.findImageByArticle(article.id);
+
+    // DESCRIBE: 기존 이미지 차집합은 삭제
+    const beforeDiff = beforeImages.filter(
+      (x) => !newImages.includes(x.image.id),
+    );
+    const removes = beforeDiff.map(async (image) => {
+      await this.remove(image.id);
+    });
+    await Promise.all(removes);
+
+    // DESCRIBE: 신규 이미지 차집합은 새로 등록
+    const newDiff = newImages.filter(
+      (x) => !beforeImages.map((x) => x.image.id).includes(x),
+    );
+    const updates = newDiff.map(async (imageId) => {
+      const image = await this.imageService.findById(imageId);
+      await this.create(image, article);
+    });
+    await Promise.all(updates);
   }
 }

--- a/packages/server/src/articleImage/articleImage.service.ts
+++ b/packages/server/src/articleImage/articleImage.service.ts
@@ -30,31 +30,30 @@ export class ArticleImageService {
     await this.articleImageRepository.delete({ id });
   }
 
-  async findImageByArticle(articleId: number): Promise<ArticleImage[]> {
-    const articleImages = await this.articleImageRepository.find({
-      where: { article: articleId },
-      relations: [ "article", "image" ],
-    });
-    return articleImages;
+  async removeByImage(imageId: number) {
+    await this.articleImageRepository.deleteByImage(imageId);
+  }
+
+  async findImageIdByArticle(articleId: number): Promise<number[]> {
+    const articleImages =
+      await this.articleImageRepository.findImageIdByArticle(articleId);
+    const result = articleImages.map(({ imageId }) => imageId);
+    return result;
   }
 
   async update(newImages: number[], article: Article) {
     // DESCRIBE: article_image 수정
-    const beforeImages = await this.findImageByArticle(article.id);
+    const beforeImages = await this.findImageIdByArticle(article.id);
 
     // DESCRIBE: 기존 이미지 차집합은 삭제
-    const beforeDiff = beforeImages.filter(
-      (x) => !newImages.includes(x.image.id),
-    );
-    const removes = beforeDiff.map(async (image) => {
-      await this.remove(image.id);
+    const beforeDiff = beforeImages.filter((x) => !newImages.includes(x));
+    const removes = beforeDiff.map(async (imageId) => {
+      await this.removeByImage(imageId);
     });
     await Promise.all(removes);
 
     // DESCRIBE: 신규 이미지 차집합은 새로 등록
-    const newDiff = newImages.filter(
-      (x) => !beforeImages.map((x) => x.image.id).includes(x),
-    );
+    const newDiff = newImages.filter((x) => !beforeImages.includes(x));
     const updates = newDiff.map(async (imageId) => {
       const image = await this.imageService.findById(imageId);
       await this.create(image, article);

--- a/packages/server/src/articleImage/articleImage.service.ts
+++ b/packages/server/src/articleImage/articleImage.service.ts
@@ -23,4 +23,15 @@ export class ArticleImageService {
 
     await this.articleImageRepository.save(articleImage);
   }
+
+  async remove(id: number) {
+    await this.articleImageRepository.delete({ id });
+  }
+
+  async findImageByArticle(articleId: number): Promise<number[]> {
+    const articleImages =
+      await this.articleImageRepository.findImageIdByArticle(articleId);
+    const result = articleImages.map(({ articleId }) => articleId);
+    return result;
+  }
 }

--- a/packages/server/src/subscribe/subscribe.repository.ts
+++ b/packages/server/src/subscribe/subscribe.repository.ts
@@ -13,6 +13,7 @@ export class SubscribeRepository extends Repository<Subscribe> {
   async findBoardByUser(userId: number) {
     return this.createQueryBuilder("subscribe")
       .select([ "board_id AS boardId" ])
+      .where("user_id = :userId", { userId })
       .getRawMany();
   }
 }


### PR DESCRIPTION
## 👀 이슈

resolve #362 

## 📌 개요

- article 수정 API에 image 수정 로직을 추가합니다.

## 👩‍💻 작업 사항

- 게시물 수정할 때 해당 게시물 이미지 수정 가능
  - article_image 테이블에서 해당 articleId 관련된 row 전체 삭제
  - 이후 article create 할 때와 마찬가지로 article_image 다시 등록

## ✅ 참고 사항

<!-- 공유할 내용, 스크린샷 등을 넣어 주세요. -->
