### PR TITLE
[server] 구독 & 알림 신청한 게시판 목록 조회 API response에 parent 필드 추가

### DIFF
--- a/packages/server/src/subscribe/dtos/subscribe.dto.ts
+++ b/packages/server/src/subscribe/dtos/subscribe.dto.ts
@@ -1,9 +1,9 @@
-export class SubscribeNoticeDto {
+export class SubscribeBaseDto {
   id: number;
   name: string;
 }
 
-export class SubscribeInfoDto extends SubscribeNoticeDto {
+export class SubscribeInfoDto extends SubscribeBaseDto {
   isNoticing: boolean;
-  parents: SubscribeNoticeDto[];
+  parents: SubscribeBaseDto[];
 }

--- a/packages/server/src/subscribe/dtos/subscribe.dto.ts
+++ b/packages/server/src/subscribe/dtos/subscribe.dto.ts
@@ -1,8 +1,9 @@
 export class SubscribeNoticeDto {
   id: number;
-  isNoticing: boolean;
+  name: string;
 }
 
 export class SubscribeInfoDto extends SubscribeNoticeDto {
-  name: string;
+  isNoticing: boolean;
+  parents: SubscribeNoticeDto[];
 }

--- a/packages/server/src/subscribe/subscribe.service.ts
+++ b/packages/server/src/subscribe/subscribe.service.ts
@@ -3,6 +3,7 @@ import { Builder } from "builder-pattern";
 import { BoardService } from "src/board/board.service";
 import { BoardTreeRepository } from "src/boardTree/boardTree.repository";
 import { Board } from "src/commons/entities/board.entity";
+import { BoardTree } from "src/commons/entities/boardTree.entity";
 import { Subscribe } from "src/commons/entities/subscribe.entity";
 import { User } from "src/commons/entities/user.entity";
 import { Errors } from "src/commons/exception/exception.global";
@@ -118,30 +119,26 @@ export class SubscribeService {
   }
 
   async getParentBoardList(board: Board): Promise<SubscribeBaseDto[]> {
-    const response: SubscribeBaseDto[] = [];
+    let response: SubscribeBaseDto[] = [];
     const boardId = board.id;
-    // while (1) {
-    //   // DESCRIBE: 현재 노드의 보드 트리 검색
-    //   const boardTree: BoardTree = await this.boardTreeRepository.findOne({
-    //     where: {
-    //       board: boardId,
-    //     },
-    //     relations: [ "board", "parentBoard" ],
-    //   });
+    const boardTree: BoardTree = await this.boardTreeRepository.findOne({
+      where: {
+        board: boardId,
+      },
+      relations: [ "board", "parentBoard" ],
+    });
 
-    //   // DESCRIBE: 보드 트리 정보 있으면 결과 추가
-    //   if (typeof boardTree !== "undefined" && boardTree.parentBoard !== null) {
-    //     const { parentBoard } = boardTree;
-    //     response.push(
-    //       Builder(SubscribeBaseDto)
-    //         .id(parentBoard.id)
-    //         .name(parentBoard.name)
-    //         .build(),
-    //     );
-    //     boardId = boardTree.parentBoard.id;
-    //   } else break;
-    // }
-
+    // DESCRIBE: 보드 트리 정보 있으면 결과 추가
+    if (typeof boardTree !== "undefined" && boardTree.parentBoard !== null) {
+      const { parentBoard } = boardTree;
+      response.push(
+        Builder(SubscribeBaseDto)
+          .id(parentBoard.id)
+          .name(parentBoard.name)
+          .build(),
+      );
+      response = response.concat(await this.getParentBoardList(parentBoard));
+    }
     return response;
   }
 }


### PR DESCRIPTION
## 👀 이슈

resolve #368 

## 📌 개요

- 로그인 한 유저가 구독 & 알림 신청을 받는 게시판 조회 API response에 parent 필드를 추가합니다.

## 👩‍💻 작업 사항

- name 필드 수정
  - 변경 전 : 뎁스 전부 포함 (`ex. "전공 > 전자정보대학 > 소프트웨어"`)
  - 변경 후 : board name만 리턴 (`ex. "소프트웨어"` )
- parents 필드 추가 
  - `오름차순`으로 소속 뎁스 구조 표현

## ✅ 참고 사항

<!-- 공유할 내용, 스크린샷 등을 넣어 주세요. -->
