### PR TITLE
[mobile] 일정 페이지 폰트에 typography mixin 적용

### DIFF
--- a/packages/mobile/src/page/Calendar/CollegeCard/style.module.scss
+++ b/packages/mobile/src/page/Calendar/CollegeCard/style.module.scss
@@ -14,7 +14,7 @@
     .period {
         margin-top: 8px;
         color: $black-40;
-        font-size: 12px;
+        @include typography(12);
     }
 
     .star {

--- a/packages/mobile/src/page/Calendar/PersonalCard/style.module.scss
+++ b/packages/mobile/src/page/Calendar/PersonalCard/style.module.scss
@@ -14,7 +14,7 @@
     .period {
         margin-top: 8px;
         color: $black-40;
-        font-size: 12px;
+        @include typography(12);
     }
 
     .link {


### PR DESCRIPTION
## 👀 이슈

resolve #377

## 📌 개요

폰트 크기를 직접 설정했던 부분에 `typography` 믹스인을 적용합니다.

## 👩‍💻 작업 사항

- `font-size` 속성 제거 및 `typography` 믹스인으로 대체

## ✅ 참고 사항

self-merge 하겠습니다!
