### PR TITLE
[server] article 상세 정보 조회 API response에 image 추가

### DIFF
--- a/packages/server/src/article/article.service.ts
+++ b/packages/server/src/article/article.service.ts
@@ -11,6 +11,7 @@ import { Article } from "src/commons/entities/article.entity";
 import { User } from "src/commons/entities/user.entity";
 import { Errors } from "src/commons/exception/exception.global";
 import { HitRepository } from "src/hit/hit.repository";
+import { ImageResponseDto } from "src/image/dto/image.response.dto";
 import { ImageService } from "src/image/image.service";
 import { SubscribeService } from "src/subscribe/subscribe.service";
 import { Transactional } from "typeorm-transactional-cls-hooked";
@@ -139,6 +140,17 @@ export class ArticleService {
       article.id,
     );
 
+    let images = [];
+    const articleImages = await this.articleImageService.findImageByArticle(id);
+    if (articleImages.length > 0 || typeof articleImages !== "undefined") {
+      images = await Promise.all(
+        articleImages.map(async (articleImage) => {
+          const { image } = articleImage;
+          return Builder(ImageResponseDto).id(image.id).url(image.url).build();
+        }),
+      );
+    }
+
     return Builder(ArticleResponseDto)
       .id(article.id)
       .board(board)
@@ -147,6 +159,7 @@ export class ArticleService {
       .hits(hitCnt)
       .scraps(bookmarkCnt)
       .dates(article.date)
+      .images(images)
       .createdAt(article.createdAt)
       .updatedAt(article.updatedAt)
       .build();

--- a/packages/server/src/article/dtos/article.dto.ts
+++ b/packages/server/src/article/dtos/article.dto.ts
@@ -1,4 +1,5 @@
 import { BoardTreeResponseDto } from "src/boardTree/dto/boardTree.response.dto";
+import { ImageResponseDto } from "src/image/dto/image.response.dto";
 
 export class ArticleBaseDto {
   id: number;
@@ -31,4 +32,5 @@ export class ArticleResponseDto extends ArticleDetailInfoDto {
   content!: string;
   createdAt!: Date;
   updatedAt!: Date;
+  images!: ImageResponseDto[];
 }

--- a/packages/server/src/articleImage/articleImage.service.ts
+++ b/packages/server/src/articleImage/articleImage.service.ts
@@ -34,6 +34,16 @@ export class ArticleImageService {
     await this.articleImageRepository.deleteByImage(imageId);
   }
 
+  async findImageByArticle(articleId: number): Promise<ArticleImage[]> {
+    const articleImages = await this.articleImageRepository.find({
+      where: {
+        article: articleId,
+      },
+      relations: [ "article", "image" ],
+    });
+    return articleImages;
+  }
+
   async findImageIdByArticle(articleId: number): Promise<number[]> {
     const articleImages =
       await this.articleImageRepository.findImageIdByArticle(articleId);

--- a/packages/server/src/image/dto/image.response.dto.ts
+++ b/packages/server/src/image/dto/image.response.dto.ts
@@ -1,0 +1,4 @@
+export class ImageResponseDto {
+  id: number;
+  url: string;
+}


### PR DESCRIPTION
## 👀 이슈

resolve #364 

## 📌 개요

- article 수정시 image pk 정보가 필요하므로 article 상세 조회 API를 수정합니다.

## 👩‍💻 작업 사항

- article 상세 정보 조회 API response에 아래 값 추가
  - image url list
  - image id list

## ✅ 참고 사항

<!-- 공유할 내용, 스크린샷 등을 넣어 주세요. -->
