### PR TITLE
[server] article 관련 API response 필드 수정

### DIFF
--- a/packages/server/src/article/article.controller.ts
+++ b/packages/server/src/article/article.controller.ts
@@ -132,7 +132,7 @@ export class ArticleController {
       .board(board)
       .title(article.title)
       .content(article.content)
-      .dates(article.date)
+      .date(article.date)
       .createdAt(article.createdAt)
       .updatedAt(article.updatedAt)
       .build();

--- a/packages/server/src/article/article.service.ts
+++ b/packages/server/src/article/article.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from "@nestjs/common";
 import { Builder } from "builder-pattern";
-import * as moment from "moment-timezone";
 import { ArticleImageService } from "src/articleImage/articleImage.service";
 import { BoardService } from "src/board/board.service";
 import { BoardTreeService } from "src/boardTree/boardTree.service";
@@ -259,14 +258,12 @@ export class ArticleService {
         const { article } = bookmark;
         const hitCnt = await this.hitRepository.count({ article });
         const bookmarkCnt = await this.bookmarkRepository.count({ article });
-
-        const formattedDate = moment(article.date).format("YY-DD-MM");
         response.push(
           Builder(ArticleListInfoDto)
             .id(article.id)
             .boardName(article.board.name)
             .title(article.title)
-            .date(formattedDate)
+            .date(article.date)
             .hits(hitCnt)
             .scraps(bookmarkCnt)
             .build(),
@@ -288,14 +285,12 @@ export class ArticleService {
       articleList.map(async (article) => {
         const hitCnt = await this.hitRepository.count({ article });
         const bookmarkCnt = await this.bookmarkRepository.count({ article });
-
-        const formattedDate = moment(article.date).format("YY-DD-MM");
         response.push(
           Builder(ArticleListInfoDto)
             .id(article.id)
             .boardName(article.board.name)
             .title(article.title)
-            .date(formattedDate)
+            .date(article.date)
             .hits(hitCnt)
             .scraps(bookmarkCnt)
             .build(),

--- a/packages/server/src/article/article.service.ts
+++ b/packages/server/src/article/article.service.ts
@@ -158,10 +158,8 @@ export class ArticleService {
       .content(article.content)
       .hits(hitCnt)
       .scraps(bookmarkCnt)
-      .dates(article.date)
+      .date(article.date)
       .images(images)
-      .createdAt(article.createdAt)
-      .updatedAt(article.updatedAt)
       .build();
   }
 
@@ -186,7 +184,7 @@ export class ArticleService {
             .title(article.title)
             .hits(hitCnt)
             .scraps(bookmarkCnt)
-            .dates(article.date)
+            .date(article.date)
             .build(),
         );
       }),

--- a/packages/server/src/article/dtos/article.create.dto.ts
+++ b/packages/server/src/article/dtos/article.create.dto.ts
@@ -1,16 +1,16 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { IsNotEmpty, IsOptional, IsString } from "class-validator";
+import { IsArray, IsNotEmpty, IsOptional, IsString } from "class-validator";
 
 export class ArticleCreateDto {
   @IsNotEmpty()
   @IsString()
   @ApiProperty({ description: "공지사항 제목" })
-  title: string;
+  title!: string;
 
   @IsNotEmpty()
   @IsString()
   @ApiProperty({ description: "공지사항 내용" })
-  content: string;
+  content!: string;
 
   @IsOptional()
   @IsString()
@@ -18,15 +18,10 @@ export class ArticleCreateDto {
   url: string;
 
   @IsNotEmpty()
-  @IsString()
   @ApiProperty({ description: "공지사항 등록 날짜 : YYYY-MM-DD" })
-  date: Date;
+  date!: Date;
 
-  @IsNotEmpty()
+  @IsArray()
   @ApiProperty({ description: "공지사항에 첨부된 이미지 id 배열" })
   images: number[];
-
-  // @IsNotEmpty()
-  // @ApiProperty({ description: "공지사항에 첨부된 이미지 url 배열" })
-  // images: string[];
 }

--- a/packages/server/src/article/dtos/article.dto.ts
+++ b/packages/server/src/article/dtos/article.dto.ts
@@ -25,7 +25,7 @@ export class ArticleDetailInfoDto extends ArticleBaseDto {
 
 export class ArticleListInfoDto extends ArticleBaseDto {
   boardName!: string;
-  date!: string;
+  date!: Date;
 }
 
 export class ArticleResponseDto extends ArticleDetailInfoDto {

--- a/packages/server/src/article/dtos/article.dto.ts
+++ b/packages/server/src/article/dtos/article.dto.ts
@@ -13,14 +13,14 @@ export class ArticleDto {
   board!: BoardTreeResponseDto;
   title!: string;
   content!: string;
-  dates!: Date;
+  date!: Date;
   createdAt!: Date;
   updatedAt!: Date;
 }
 
 export class ArticleDetailInfoDto extends ArticleBaseDto {
   board: BoardTreeResponseDto;
-  dates: Date;
+  date: Date;
 }
 
 export class ArticleListInfoDto extends ArticleBaseDto {
@@ -30,7 +30,5 @@ export class ArticleListInfoDto extends ArticleBaseDto {
 
 export class ArticleResponseDto extends ArticleDetailInfoDto {
   content!: string;
-  createdAt!: Date;
-  updatedAt!: Date;
   images!: ImageResponseDto[];
 }


### PR DESCRIPTION
## 👀 이슈

resolve #383 

## 📌 개요

- article 관련 API의 response 필드를 수정합니다.

## 👩‍💻 작업 사항

- 모든 article 관련 API에서 date 필드 수정
  - 이름 변경 : dates -> date
  - 포맷 고정 : ISO 8601 :: DB 들어온 값 그대로
- article 상세 정보 조회 API에서 `createdAt`, `updatedAt` 필드 삭제

## ✅ 참고 사항

<!-- 공유할 내용, 스크린샷 등을 넣어 주세요. -->
