### PR TITLE
[server] 요청 크기 제한 늘리기

### DIFF
--- a/packages/server/src/main.ts
+++ b/packages/server/src/main.ts
@@ -18,8 +18,8 @@ async function bootstrap() {
   app.enableCors({
     origin: "*",
   });
-  app.use(express.json());
-  app.use(express.urlencoded({ extended: true }));
+  app.use(express.json({ limit: "50mb" }));
+  app.use(express.urlencoded({ limit: "50mb", extended: true }));
   app.useGlobalFilters(new HttpExceptionFilter());
   app.useGlobalPipes(
     new ValidationPipe({


### PR DESCRIPTION
## 👀 이슈

스크래퍼 본문의 크기가 서버의 제한을 넘음

## 📌 개요

서버의 request 제한을 늘림

## 👩‍💻 작업 사항

https://stackoverflow.com/questions/52783959/nest-js-request-entity-too-large-payloadtoolargeerror-request-entity-too-larg