### PR TITLE
[server] Admin Master, Council guard 생성

### DIFF
--- a/packages/server/src/commons/guards/admin-council.guard.ts
+++ b/packages/server/src/commons/guards/admin-council.guard.ts
@@ -1,0 +1,15 @@
+import { CanActivate, ExecutionContext, Injectable } from "@nestjs/common";
+
+import { Authority } from "../constants/enums";
+
+@Injectable()
+export class AdminCouncilGuard implements CanActivate {
+  canActivate(context: ExecutionContext) {
+    const req = context.switchToHttp().getRequest();
+
+    return !!(
+      req.admin.authority === Authority.StudentCouncil ||
+      req.admin.authority === Authority.Super
+    );
+  }
+}

--- a/packages/server/src/commons/guards/admin-master.guard.ts
+++ b/packages/server/src/commons/guards/admin-master.guard.ts
@@ -1,0 +1,12 @@
+import { CanActivate, ExecutionContext, Injectable } from "@nestjs/common";
+
+import { Authority } from "../constants/enums";
+
+@Injectable()
+export class AdminMasterGuard implements CanActivate {
+  canActivate(context: ExecutionContext) {
+    const req = context.switchToHttp().getRequest();
+
+    return !!(req.admin.authority === Authority.Super);
+  }
+}

--- a/packages/server/src/weather/weather.controller.ts
+++ b/packages/server/src/weather/weather.controller.ts
@@ -1,7 +1,6 @@
 import { Controller, Get } from "@nestjs/common";
 import { ApiOperation, ApiResponse, ApiTags } from "@nestjs/swagger";
 
-import { Public } from "../commons/decorators/public.decorator";
 import { Weather } from "../commons/entities/weather.entity";
 import { GetWeatherResponseDto } from "./dtos/get-weather.response.dto";
 import { WeatherService } from "./weather.service";
@@ -11,7 +10,6 @@ import { WeatherService } from "./weather.service";
 export class WeatherController {
   constructor(private readonly weatherService: WeatherService) {}
 
-  @Public()
   @Get()
   @ApiOperation({
     summary: "날씨 조회 API",


### PR DESCRIPTION
## 👀 이슈

resolve #

## 📌 개요

Admin Master, Council guard를 생성합니다.

## 👩‍💻 작업 사항

Admin 접근 권한을 분리하기 위해 AdminMasterGuard와 AdminCouncilGuard를 생성합니다.

## ✅ 참고 사항

권한이 필요한 API에 @useGuard 데코레이터와 함께 적용해야 합니다.