### PR TITLE
[mobile] 홈 오늘의 일정 카드 스타일링

### DIFF
--- a/packages/mobile/src/__mocks__/schedules.ts
+++ b/packages/mobile/src/__mocks__/schedules.ts
@@ -1,7 +1,8 @@
 const COLLEGE_SCHEDULES = [
   {
     id: 0,
-    content: "학사일정",
+    content:
+      "학사일정 학사일정학사일정학사일정학사일정학사일정학사일정학사일정학사일정학사일정학사일정학사일정학사일정학사일정학사일정",
     priority: 0,
     isHoliyday: 0 as const,
     startDate: "2022-05-30T00:00:00",

--- a/packages/mobile/src/page/Home/Schedule/index.tsx
+++ b/packages/mobile/src/page/Home/Schedule/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import classNames from "classnames";
 import dayjs, { Dayjs } from "dayjs";
@@ -18,12 +18,9 @@ type Props = {
 };
 
 function Schedule({ content, startDate, endDate, today }: Props) {
-  const period = useMemo(() => {
-    const start = dayjs(startDate);
-    const end = endDate ? dayjs(endDate) : null;
-    const period = getTimePeriod(start, end, today);
-    return period;
-  }, [ startDate, endDate ]);
+  const start = dayjs(startDate);
+  const end = endDate ? dayjs(endDate) : null;
+  const period = getTimePeriod(start, end, today);
   const ref = useRef<HTMLSpanElement>(null);
   const [ isLong, setIsLong ] = useState(false);
 

--- a/packages/mobile/src/page/Home/Schedule/index.tsx
+++ b/packages/mobile/src/page/Home/Schedule/index.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import classNames from "classnames";
+import dayjs, { Dayjs } from "dayjs";
+import BorderBox from "src/components/atoms/BorderBox";
+import { LongArrow } from "src/components/atoms/icon";
+import { getTimePeriod } from "src/utils/calendarTools";
+
+import $ from "./style.module.scss";
+
+const MAX_WIDTH = 23 as const;
+
+type Props = {
+  content: string;
+  startDate: string;
+  endDate: string | null;
+  today: Dayjs;
+};
+
+function Schedule({ content, startDate, endDate, today }: Props) {
+  const period = useMemo(() => {
+    const start = dayjs(startDate);
+    const end = endDate ? dayjs(endDate) : null;
+    const period = getTimePeriod(start, end, today);
+    return period;
+  }, [ startDate, endDate ]);
+  const ref = useRef<HTMLSpanElement>(null);
+  const [ isLong, setIsLong ] = useState(false);
+
+  useEffect(() => {
+    const spanHeight = ref.current?.clientHeight;
+    if (!spanHeight) return;
+    if (spanHeight > MAX_WIDTH) {
+      setIsLong(true);
+      return;
+    }
+    setIsLong(false);
+  }, []);
+
+  return (
+    <BorderBox width={270} height={100} className={$.container}>
+      <div>
+        <span
+          ref={ref}
+          className={classNames(
+            $["schedule-name"],
+            isLong && $["long-schedule-name"],
+          )}
+        >
+          {content}
+        </span>
+        <time className={$.period}>{period}</time>
+      </div>
+      <LongArrow size={8} stroke="#aaa" />
+    </BorderBox>
+  );
+}
+
+export default Schedule;

--- a/packages/mobile/src/page/Home/Schedule/index.tsx
+++ b/packages/mobile/src/page/Home/Schedule/index.tsx
@@ -39,10 +39,9 @@ function Schedule({ content, startDate, endDate, today }: Props) {
       <div>
         <span
           ref={ref}
-          className={classNames(
-            $["schedule-name"],
-            isLong && $["long-schedule-name"],
-          )}
+          className={classNames($["schedule-name"], {
+            [$["long-schedule-name"]]: isLong,
+          })}
         >
           {content}
         </span>

--- a/packages/mobile/src/page/Home/Schedule/style.module.scss
+++ b/packages/mobile/src/page/Home/Schedule/style.module.scss
@@ -1,0 +1,38 @@
+@import "../../../styles/main.scss";
+
+.container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-width: 270px;
+  padding-left: 20px;
+  padding-right: 20px;
+  margin-right: 23px;
+  margin-bottom: 35px;
+
+  .schedule-name {
+    width: 195px;
+    display: -webkit-box;
+    overflow: hidden;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    @include typography(16);
+    font-weight: 500;
+    line-height: 23px;
+    color: $black-80;
+  }
+
+  .long-schedule-name {
+    font-size: 14px;
+  }
+
+  .period {
+    margin-top: 9px;
+    @include typography(12);
+    color: $black-40;
+  }
+
+  &:last-child {
+    margin-right: 0;
+  }
+}

--- a/packages/mobile/src/page/Home/Schedule/style.module.scss
+++ b/packages/mobile/src/page/Home/Schedule/style.module.scss
@@ -1,21 +1,17 @@
 @import "../../../styles/main.scss";
+@import "../../../../../shared/src/styles/mixin.scss";
 
 .container {
   display: flex;
   align-items: center;
   justify-content: space-between;
   min-width: 270px;
-  padding-left: 20px;
-  padding-right: 20px;
-  margin-right: 23px;
-  margin-bottom: 35px;
+  padding: 0 20px;
+  margin: 0 23px 35px 0;
 
   .schedule-name {
     width: 195px;
-    display: -webkit-box;
-    overflow: hidden;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
+    @include ellipsis(2);
     @include typography(16);
     font-weight: 500;
     line-height: 23px;

--- a/packages/mobile/src/page/Home/Schedule/style.module.scss
+++ b/packages/mobile/src/page/Home/Schedule/style.module.scss
@@ -1,5 +1,5 @@
-@import "../../../styles/main.scss";
-@import "../../../../../shared/src/styles/mixin.scss";
+@import "src/styles/main.scss";
+@import "@shared/styles/mixin.scss";
 
 .container {
   display: flex;

--- a/packages/mobile/src/page/Home/index.tsx
+++ b/packages/mobile/src/page/Home/index.tsx
@@ -1,14 +1,18 @@
+import { useMemo } from "react";
 import { Link, useSearchParams } from "react-router-dom";
 
 import Footer from "@components/molecules/Footer";
+import dayjs from "dayjs";
+import { COLLEGE_SCHEDULES } from "src/__mocks__/schedules";
 import { usePopularArticles } from "src/api/article";
 import { useSchedule } from "src/api/schedule";
 import BorderBox from "src/components/atoms/BorderBox";
-import { LeftArrow, Setting } from "src/components/atoms/icon";
+import { Setting } from "src/components/atoms/icon";
 import Line from "src/components/atoms/Line";
 import Weather from "src/page/Home/Weather";
 
 import Restaurant from "./Restaurant";
+import Schedule from "./Schedule";
 import $ from "./style.module.scss";
 
 function Home() {
@@ -24,6 +28,9 @@ function Home() {
     isLoading: scheduleLoading,
     isError: scheduleError,
   } = useSchedule();
+  const today = useMemo(() => {
+    return dayjs();
+  }, []);
 
   if (popularArticleLoading || scheduleLoading) return <div>로딩중입니다.</div>;
   if (popularArticleError || scheduleError)
@@ -40,19 +47,16 @@ function Home() {
       <header className={$.header}>
         <div className={$["header-content"]}>
           <h1 className={$.title}>충림이</h1>
-          <p>오늘은 총 6개의 일정이 있어요</p>
+          <p>오늘은 총 {COLLEGE_SCHEDULES.length}개의 일정이 있어요</p>
         </div>
         <Link to="/setting">
           <Setting size={24} stroke="#aaa" />
         </Link>
       </header>
       <div className={$.schedule}>
-        {schedules.map((schedule) => {
+        {COLLEGE_SCHEDULES.map(({ id, content, startDate, endDate }) => {
           return (
-            <BorderBox key={schedule.id} width={271} height={101}>
-              <p>{schedule.content}</p>
-              <LeftArrow size={7} stroke="#aaa" />
-            </BorderBox>
+            <Schedule key={id} {...{ content, startDate, endDate, today }} />
           );
         })}
       </div>

--- a/packages/mobile/src/page/Home/index.tsx
+++ b/packages/mobile/src/page/Home/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { isAndroid, isIOS } from "react-device-detect";
 import { Link, useSearchParams } from "react-router-dom";
 
@@ -36,9 +36,7 @@ function Home() {
     isLoading: scheduleLoading,
     isError: scheduleError,
   } = useSchedule();
-  const today = useMemo(() => {
-    return dayjs();
-  }, []);
+  const today = dayjs();
 
   useEffect(() => {
     if (window.ReactNativeWebView) {

--- a/packages/mobile/src/page/Home/style.module.scss
+++ b/packages/mobile/src/page/Home/style.module.scss
@@ -32,26 +32,6 @@
         display: flex;
         flex-wrap: nowrap;
         overflow-x: auto;
-        > div {
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
-            padding-left: 20px;
-            padding-right: 20px;
-            margin-right: 23px;
-            margin-bottom: 35px;
-            min-width: 70%;
-            @include typography(16);
-            font-weight: 500;
-            color: $black-80;
-        }
-        > div:last-child {
-            margin-right: 0;
-        }
-        > p {
-            padding-right: 10px;
-            line-height: 24px;
-        }
     }
 
     .show-guide {


### PR DESCRIPTION
## 👀 이슈

resolve #415

## 📌 개요

홈 화면 위에 보이는 오늘의 일정 카드를 디자인 가이드에 맞게 꾸몄습니다.

## 👩‍💻 작업 사항

- 홈 `index.tsx`에서 오늘 날짜 정보를 알 수 있도록 함.
- 일정 카드 컴포넌트 별도로 분리.
- 기존 캘린더 툴에서 
- 일정 제목이 두 줄일 때 글자 크기를 바꾸는 로직 구현.

## ✅ 참고 사항

- 일정 제목이 두 줄을 넘길 경우에는 `span` 태그의 `clientHeight` 값으로 감지하여 폰트 사이즈를 줄였습니다.
- 일정 제목이 세 줄을 넘길 경우에는 `-webkit-line-clamp` 속성을 썼을 때 너무 깔끔하게 적용되어서 해당 속성으로 구현하였습니다.
  - 제 환경에서는 크롬, 사파리, IOS 사파리, 안드로이드 크롬 모두 문제 없었습니다!
  - [line-clamp suppert list](https://caniuse.com/?search=webkit-box)
 
<img width="329" alt="image" src="https://user-images.githubusercontent.com/71015915/183670490-d3c2ecf8-7115-4337-8fe1-87ec984c43d4.png">
<img width="349" alt="스크린샷 2022-08-09 오후 10 38 45" src="https://user-images.githubusercontent.com/71015915/183669715-d451dd88-ea27-4cf9-a618-819d1006eec6.png">
<img width="360" alt="스크린샷 2022-08-09 오후 10 37 49" src="https://user-images.githubusercontent.com/71015915/183669675-6d20f0b6-80b9-46f6-9c2c-da5f22689a82.png">
<img width="297" alt="스크린샷 2022-08-09 오후 10 38 04" src="https://user-images.githubusercontent.com/71015915/183669701-7fdfed66-5c2e-442c-b0eb-aeadec4f86f4.png">
<img width="296" alt="스크린샷 2022-08-09 오후 10 38 24" src="https://user-images.githubusercontent.com/71015915/183669710-f137c0ab-9bf9-4c5c-90b4-649c7f62f843.png">

