### PR TITLE
[server] 특정 공지사항 상세 정보 API res에 로그인 유저 북마크 여부 추가

### DIFF
--- a/packages/server/src/article/article.controller.ts
+++ b/packages/server/src/article/article.controller.ts
@@ -7,6 +7,7 @@ import {
   Post,
   Put,
   Query,
+  Req,
   UseGuards,
 } from "@nestjs/common";
 import {
@@ -81,15 +82,22 @@ export class ArticleController {
     description:
       "공지사항 id(pk)를 이용, 해당 공지사항의 상세 정보를 조회한다.",
   })
+  @ApiHeader({
+    name: "uuid",
+    description: "로그인 유저 uuid",
+    required: false,
+  })
   @ApiResponse({
     status: 200,
     description: "요청 공지사항의 상세 정보",
     type: ArticleResponseDto,
   })
   async findById(
+    @Req() req,
     @Param("articleId") articleId: number,
   ): Promise<ArticleResponseDto> {
-    return this.articleService.findArticleRes(articleId);
+    const { user } = req;
+    return this.articleService.findArticleRes(articleId, user);
   }
 
   @Post("/boards/:boardId/article")

--- a/packages/server/src/article/article.service.ts
+++ b/packages/server/src/article/article.service.ts
@@ -191,7 +191,7 @@ export class ArticleService {
     return response;
   }
 
-  async findArticleRes(id: number): Promise<ArticleResponseDto> {
+  async findArticleRes(id: number, user: User): Promise<ArticleResponseDto> {
     const article = await this.findById(id);
     const board: BoardTreeResponseDto =
       await this.boardTreeService.getBoardTree(article.board.id);
@@ -199,6 +199,15 @@ export class ArticleService {
     const bookmarkCnt = await this.bookmarkRepository.countByArticle(
       article.id,
     );
+
+    // DESCRIBE: articleid와 uuid로 bookmark 여부 확인
+    const isBookmark: boolean =
+      user === undefined
+        ? undefined
+        : (await this.bookmarkRepository.existsByUserAndArticle(
+            user.id,
+            article.id,
+          )) === 1;
 
     let images = [];
     const articleImages = await this.articleImageService.findImageByArticle(id);
@@ -219,6 +228,7 @@ export class ArticleService {
       .hits(hitCnt)
       .scraps(bookmarkCnt)
       .date(article.date)
+      .isBookmark(isBookmark)
       .images(images)
       .build();
   }

--- a/packages/server/src/article/dtos/article.dto.ts
+++ b/packages/server/src/article/dtos/article.dto.ts
@@ -30,5 +30,6 @@ export class ArticleListInfoDto extends ArticleBaseDto {
 
 export class ArticleResponseDto extends ArticleDetailInfoDto {
   content!: string;
-  images!: ImageResponseDto[];
+  isBookmark: boolean;
+  images: ImageResponseDto[];
 }


### PR DESCRIPTION
## 👀 이슈

resolve #431 

## 📌 개요

- 특정 공지사항을 조회했을 때, 로그인 유저가 북마크한 공지사항인지 알려주어야 합니다.

## 👩‍💻 작업 사항

- 공지사항(article) 상세 조회 API를 수정합니다. (/boards/articles/{articleId})
  - request header로 uuid를 받아 로그인 유저 정보 확인
  - 북마크 여부를 표시하는 res 필드 추가
    - 만약 url 공유로 조회한 경우 (로그인 유저 없는 경우) undefined 처리 필요

## ✅ 참고 사항

<!-- 공유할 내용, 스크린샷 등을 넣어 주세요. -->
