### PR TITLE
[mobile] 스타일 사이드 이펙트 수정

### DIFF
--- a/packages/mobile/src/page/Subscription/Setting/style.module.scss
+++ b/packages/mobile/src/page/Subscription/Setting/style.module.scss
@@ -1,18 +1,12 @@
 .setting {
   .content {
     padding: 8px;
-    background: #F3F4FA;
+    background: #f3f4fa;
   }
-  
+
   img {
     width: 100%;
     padding-top: 50%;
     object-fit: scale-down;
-  }  
-}
-
-img {
-  width: 100%;
-  padding-top: 50%;
-  object-fit: scale-down;
+  }
 }


### PR DESCRIPTION
## 👀 이슈

resolve #435

## 📌 개요

- 문맥상으로 중복된 스타일인 것 같아 사이드 이펙트를 일으키는 스타일을 제거했습니다.

## 👩‍💻 작업 사항

- 최상단 `img` 태그선택자 스타일 제거

## ✅ 참고 사항

- 해당 스타일 제거 후 사이드 이펙트가 없어졌습니다.
