### PR TITLE
[mobile] SVG height 속성 auto에서 100%로 바꾸기

### DIFF
--- a/packages/mobile/src/components/atoms/icon/Airplane.tsx
+++ b/packages/mobile/src/components/atoms/icon/Airplane.tsx
@@ -4,7 +4,7 @@ function Airplane({ size, stroke }: IconProps) {
   return (
     <svg
       width={size}
-      height="auto"
+      height="100%"
       viewBox="0 0 19 19"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/packages/mobile/src/components/atoms/icon/Alarm.tsx
+++ b/packages/mobile/src/components/atoms/icon/Alarm.tsx
@@ -4,7 +4,7 @@ function Alarm({ size, stroke }: IconProps) {
   return (
     <svg
       width={size}
-      height="auto"
+      height="100%"
       viewBox="0 0 14 14"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/packages/mobile/src/components/atoms/icon/AppVersion.tsx
+++ b/packages/mobile/src/components/atoms/icon/AppVersion.tsx
@@ -4,7 +4,7 @@ function AppVersion({ size, stroke }: IconProps) {
   return (
     <svg
       width={size}
-      height="auto"
+      height="100%"
       viewBox="0 0 14 14"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/packages/mobile/src/components/atoms/icon/Arrow.tsx
+++ b/packages/mobile/src/components/atoms/icon/Arrow.tsx
@@ -10,7 +10,7 @@ function Arrow({ size, stroke, style }: Props) {
   return (
     <svg
       width={size}
-      height="auto"
+      height="100%"
       style={style}
       viewBox="0 0 7 14"
       fill="none"

--- a/packages/mobile/src/components/atoms/icon/Calendar.tsx
+++ b/packages/mobile/src/components/atoms/icon/Calendar.tsx
@@ -4,7 +4,7 @@ function Calendar({ size, stroke }: IconProps) {
   return (
     <svg
       width={size}
-      height="auto"
+      height="100%"
       viewBox="0 0 16 14"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/packages/mobile/src/components/atoms/icon/Call.tsx
+++ b/packages/mobile/src/components/atoms/icon/Call.tsx
@@ -4,7 +4,7 @@ function Call({ size, stroke }: IconProps) {
   return (
     <svg
       width={size}
-      height="auto"
+      height="100%"
       viewBox="0 0 11 14"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/packages/mobile/src/components/atoms/icon/Close.tsx
+++ b/packages/mobile/src/components/atoms/icon/Close.tsx
@@ -4,7 +4,7 @@ function Close({ size, stroke }: IconProps) {
   return (
     <svg
       width={size}
-      height="auto"
+      height="100%"
       viewBox="0 0 13 13"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/packages/mobile/src/components/atoms/icon/Email.tsx
+++ b/packages/mobile/src/components/atoms/icon/Email.tsx
@@ -4,7 +4,7 @@ function Email({ size, stroke }: IconProps) {
   return (
     <svg
       width={size}
-      height="auto"
+      height="100%"
       viewBox="0 0 18 13"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/packages/mobile/src/components/atoms/icon/Food.tsx
+++ b/packages/mobile/src/components/atoms/icon/Food.tsx
@@ -4,7 +4,7 @@ function Food({ size, stroke }: IconProps) {
   return (
     <svg
       width={size}
-      height="auto"
+      height="100%"
       viewBox="0 0 13 14"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/packages/mobile/src/components/atoms/icon/Hamburger.tsx
+++ b/packages/mobile/src/components/atoms/icon/Hamburger.tsx
@@ -4,7 +4,7 @@ function Hamburger({ size, stroke }: IconProps) {
   return (
     <svg
       width={size}
-      height="auto"
+      height="100%"
       viewBox="0 0 14 11"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/packages/mobile/src/components/atoms/icon/Home.tsx
+++ b/packages/mobile/src/components/atoms/icon/Home.tsx
@@ -4,7 +4,7 @@ function Home({ size, stroke }: IconProps) {
   return (
     <svg
       width={size}
-      height="auto"
+      height="100%"
       viewBox="0 0 16 14"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/packages/mobile/src/components/atoms/icon/Info.tsx
+++ b/packages/mobile/src/components/atoms/icon/Info.tsx
@@ -4,7 +4,7 @@ function Info({ size, stroke }: IconProps) {
   return (
     <svg
       width={size}
-      height="auto"
+      height="100%"
       viewBox="0 0 13 13"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/packages/mobile/src/components/atoms/icon/Internet.tsx
+++ b/packages/mobile/src/components/atoms/icon/Internet.tsx
@@ -4,7 +4,7 @@ function Internet({ size, stroke }: IconProps) {
   return (
     <svg
       width={size}
-      height="auto"
+      height="100%"
       viewBox="0 0 22 22"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/packages/mobile/src/components/atoms/icon/Lab.tsx
+++ b/packages/mobile/src/components/atoms/icon/Lab.tsx
@@ -4,7 +4,7 @@ function Lab({ size, stroke }: IconProps) {
   return (
     <svg
       width={size}
-      height="auto"
+      height="100%"
       viewBox="0 0 10 12"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/packages/mobile/src/components/atoms/icon/LeftArrow.tsx
+++ b/packages/mobile/src/components/atoms/icon/LeftArrow.tsx
@@ -4,7 +4,7 @@ function LeftArrow({ size, stroke }: IconProps) {
   return (
     <svg
       width={size}
-      height="auto"
+      height="100%"
       viewBox="0 0 14 14"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/packages/mobile/src/components/atoms/icon/LongArrow.tsx
+++ b/packages/mobile/src/components/atoms/icon/LongArrow.tsx
@@ -4,7 +4,7 @@ function LongArrow({ size, stroke }: IconProps) {
   return (
     <svg
       width={size}
-      height="auto"
+      height="100%"
       viewBox="0 0 6 14"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/packages/mobile/src/components/atoms/icon/Map.tsx
+++ b/packages/mobile/src/components/atoms/icon/Map.tsx
@@ -4,7 +4,7 @@ function Map({ size, stroke }: IconProps) {
   return (
     <svg
       width={size}
-      height="auto"
+      height="100%"
       viewBox="0 0 11 14"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/packages/mobile/src/components/atoms/icon/Person.tsx
+++ b/packages/mobile/src/components/atoms/icon/Person.tsx
@@ -4,7 +4,7 @@ function Person({ size, stroke }: IconProps) {
   return (
     <svg
       width={size}
-      height="auto"
+      height="100%"
       viewBox="0 0 13 13"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/packages/mobile/src/components/atoms/icon/Plus.tsx
+++ b/packages/mobile/src/components/atoms/icon/Plus.tsx
@@ -4,7 +4,7 @@ function Plus({ size, stroke }: IconProps) {
   return (
     <svg
       width={size}
-      height="auto"
+      height="100%"
       viewBox="0 0 14 14"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/packages/mobile/src/components/atoms/icon/Setting.tsx
+++ b/packages/mobile/src/components/atoms/icon/Setting.tsx
@@ -4,7 +4,7 @@ function Setting({ size, stroke }: IconProps) {
   return (
     <svg
       width={size}
-      height="auto"
+      height="100%"
       viewBox="0 0 24 26"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/packages/mobile/src/components/atoms/icon/Share.tsx
+++ b/packages/mobile/src/components/atoms/icon/Share.tsx
@@ -4,7 +4,7 @@ function Share({ size, stroke }: IconProps) {
   return (
     <svg
       width={size}
-      height="auto"
+      height="100%"
       viewBox="0 0 22 22"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/packages/mobile/src/components/atoms/icon/Speaker.tsx
+++ b/packages/mobile/src/components/atoms/icon/Speaker.tsx
@@ -4,7 +4,7 @@ function Speaker({ size, stroke }: IconProps) {
   return (
     <svg
       width={size}
-      height="auto"
+      height="100%"
       viewBox="0 0 24 22"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/packages/mobile/src/components/atoms/icon/Star.tsx
+++ b/packages/mobile/src/components/atoms/icon/Star.tsx
@@ -4,7 +4,7 @@ function Star({ size, stroke, fill }: IconProps) {
   return (
     <svg
       width={size}
-      height="auto"
+      height="100%"
       viewBox="0 0 14 14"
       fill={fill || "none"}
       xmlns="http://www.w3.org/2000/svg"

--- a/packages/mobile/src/components/atoms/icon/Subscription.tsx
+++ b/packages/mobile/src/components/atoms/icon/Subscription.tsx
@@ -1,12 +1,10 @@
-import * as React from "react";
-
 import { IconProps } from "src/type/props";
 
 function Subscription({ size, stroke, style }: IconProps) {
   return (
     <svg
       width={size}
-      height="auto"
+      height="100%"
       style={style}
       viewBox="0 0 21 13"
       fill="none"

--- a/packages/mobile/src/components/atoms/icon/Theme.tsx
+++ b/packages/mobile/src/components/atoms/icon/Theme.tsx
@@ -4,7 +4,7 @@ function Theme({ size, stroke }: IconProps) {
   return (
     <svg
       width={size}
-      height="auto"
+      height="100%"
       viewBox="0 0 13 14"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/packages/mobile/src/components/atoms/icon/Time.tsx
+++ b/packages/mobile/src/components/atoms/icon/Time.tsx
@@ -4,7 +4,7 @@ function Time({ size, stroke }: IconProps) {
   return (
     <svg
       width={size}
-      height="auto"
+      height="100%"
       viewBox="0 0 14 14"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/packages/mobile/src/components/atoms/icon/UnAlarm.tsx
+++ b/packages/mobile/src/components/atoms/icon/UnAlarm.tsx
@@ -9,7 +9,7 @@ function UnAlarm({ size, stroke }: IconProps) {
   return (
     <svg
       width={size}
-      height="auto"
+      height="100%"
       viewBox="0 0 14 14"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/packages/mobile/src/components/atoms/icon/UnSubscription.tsx
+++ b/packages/mobile/src/components/atoms/icon/UnSubscription.tsx
@@ -4,7 +4,7 @@ function UnSubscription({ size, stroke, style }: IconProps) {
   return (
     <svg
       width={size}
-      height="auto"
+      height="100%"
       style={style}
       viewBox="0 0 22 15"
       fill="none"

--- a/packages/mobile/src/components/atoms/icon/Write.tsx
+++ b/packages/mobile/src/components/atoms/icon/Write.tsx
@@ -4,7 +4,7 @@ function Write({ size, stroke }: IconProps) {
   return (
     <svg
       width={size}
-      height="auto"
+      height="100%"
       viewBox="0 0 14 14"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/packages/mobile/src/page/Home/style.module.scss
+++ b/packages/mobile/src/page/Home/style.module.scss
@@ -28,12 +28,6 @@
       cursor: pointer;
     }
 
-    .schedule {
-        display: flex;
-        flex-wrap: nowrap;
-        overflow-x: auto;
-    }
-
     > div:last-child {
       margin-right: 0;
     }
@@ -42,6 +36,12 @@
       padding-right: 10px;
       line-height: 24px;
     }
+  }
+
+  .schedule {
+    display: flex;
+    flex-wrap: nowrap;
+    overflow-x: auto;
   }
 
   .show-guide {


### PR DESCRIPTION
## 👀 이슈

resolve #433

## 📌 개요

- SVG 태그의 `height` 속성 관련하여 콘솔에 에러가 떴습니다.
- `auto`로 되어있는 속성들을 같은 기능을 하는 `100%`로 바꿔주었습니다.
- 자세한 내용은 이슈를 참고해주세요!
- 또한, 모바일 홈 오늘의 일정 카드에 스타일이 잘못된 부분이 있어 이번 PR에 반영했습니다.

## 👩‍💻 작업 사항

- SVG 아이콘 `height` 태그 수정
- 모바일 홈 일정 카드 스타일 수정

## ✅ 참고 사항

![image](https://user-images.githubusercontent.com/71015915/184074074-2cb42946-cbea-40d0-a294-21ceb618306c.png)
![image](https://user-images.githubusercontent.com/71015915/184074115-04c57bad-35c6-4353-a7c5-37dc1a704979.png)
