### PR TITLE
[server] 공지사항 조회수 관리

### DIFF
--- a/packages/server/src/article/article.module.ts
+++ b/packages/server/src/article/article.module.ts
@@ -6,6 +6,7 @@ import { BoardModule } from "src/board/board.module";
 import { BoardTreeModule } from "src/boardTree/boardTree.module";
 import { BookmarkRepository } from "src/bookmark/bookmark.repository";
 import { FcmModule } from "src/fcm/fcm.module";
+import { HitModule } from "src/hit/hit.module";
 import { HitRepository } from "src/hit/hit.repository";
 import { ImageModule } from "src/image/image.module";
 import { SubscribeModule } from "src/subscribe/subscribe.module";
@@ -29,6 +30,7 @@ import { ArticleService } from "./article.service";
     BoardTreeModule,
     SubscribeModule,
     ImageModule,
+    HitModule,
     FcmModule,
     UserModule,
     ArticleImageModule,

--- a/packages/server/src/hit/hit.repository.ts
+++ b/packages/server/src/hit/hit.repository.ts
@@ -8,4 +8,14 @@ export class HitRepository extends Repository<Hit> {
       .where("hit.article_id = :articleId", { articleId })
       .getCount();
   }
+
+  async existsByUserAndArticle(
+    userId: number,
+    articleId: number,
+  ): Promise<number> {
+    return this.createQueryBuilder("hit")
+      .where("hit.user_id = :userId", { userId })
+      .andWhere("hit.article_id = :articleId", { articleId })
+      .getCount();
+  }
 }

--- a/packages/server/src/hit/hit.service.ts
+++ b/packages/server/src/hit/hit.service.ts
@@ -1,8 +1,23 @@
 import { Injectable } from "@nestjs/common";
+import { Builder } from "builder-pattern";
+import { Article } from "src/commons/entities/article.entity";
+import { Hit } from "src/commons/entities/hit.entity";
+import { User } from "src/commons/entities/user.entity";
 
 import { HitRepository } from "./hit.repository";
 
 @Injectable()
 export class HitService {
   constructor(private readonly hitRepository: HitRepository) {}
+
+  async create(user: User, article: Article) {
+    if (
+      (await this.hitRepository.existsByUserAndArticle(user.id, article.id)) > 0
+    )
+      return;
+
+    await this.hitRepository.save(
+      Builder(Hit).article(article).user(user).build(),
+    );
+  }
 }


### PR DESCRIPTION
## 👀 이슈

resolve #432 

## 📌 개요

- 특정 공지사항을 상세 조회할 경우 조회수를 +1 해야 합니다.

## 👩‍💻 작업 사항

- 공지사항 상세 조회 API 호출 시 해당 공지사항의 조회수 +1
  - 로그인 유저가 없는 경우 제외
  - 로그인 유저가 이미 해당 공지사항을 조회한 적이 있다면 제외

## ✅ 참고 사항

<!-- 공유할 내용, 스크린샷 등을 넣어 주세요. -->
