### PR TITLE
[server] 게시물 content 사이즈 mediumtext로 사이즈 변경

### DIFF
--- a/packages/server/src/commons/entities/article.entity.ts
+++ b/packages/server/src/commons/entities/article.entity.ts
@@ -32,7 +32,7 @@ export class Article extends UpdatableCommonEntity {
   @Column({ type: "varchar" })
   title: string;
 
-  @Column({ type: "text" })
+  @Column({ type: "mediumtext" })
   content: string;
 
   @Column({ type: "varchar", nullable: true })


### PR DESCRIPTION
## 👀 이슈

게시물의 content사이즈가 `text`라서 스크래핑한 html이 다 안담기고 `too long content`에러가 발생하는 경우가 있음

## 📌 개요

게시물 content 사이즈 mediumtext로 사이즈 변경

## 👩‍💻 작업 사항

게시물 content 사이즈 mediumtext로 사이즈 변경

## ✅ 참고 사항

[MySQL 데이터형 및 크기](https://blog.lael.be/post/115)