### PR TITLE
[server] 유저가 알림 or 구독 설정한 게시판 조회 API res 추가

### DIFF
--- a/packages/server/src/subscribe/dtos/subscribe.dto.ts
+++ b/packages/server/src/subscribe/dtos/subscribe.dto.ts
@@ -1,5 +1,5 @@
 export class SubscribeBaseDto {
-  id: number;
+  boardId: number;
   name: string;
 }
 

--- a/packages/server/src/subscribe/subscribe.service.ts
+++ b/packages/server/src/subscribe/subscribe.service.ts
@@ -110,7 +110,7 @@ export class SubscribeService {
         const { board } = subscribe;
         const parentList = await this.getParentBoardList(board);
         return Builder(SubscribeInfoDto)
-          .id(subscribe.id)
+          .boardId(subscribe.board.id)
           .name(board.name)
           .isNoticing(subscribe.notice)
           .parents(parentList)
@@ -135,7 +135,7 @@ export class SubscribeService {
       const { parentBoard } = boardTree;
       response.push(
         Builder(SubscribeBaseDto)
-          .id(parentBoard.id)
+          .boardId(parentBoard.id)
           .name(parentBoard.name)
           .build(),
       );


### PR DESCRIPTION
## 👀 이슈

resolve #453 

## 📌 개요

- res에 구독 id가 아닌, 구독 중인 게시판의 id가 필요합니다 

## 👩‍💻 작업 사항

- 유저가 알림 or 구독 설정한 게시판 조회 API res의 id 필드를 구독 중인 board의 origin board (루트 보드)로 변경합니다

## ✅ 참고 사항

<!-- 공유할 내용, 스크린샷 등을 넣어 주세요. -->
