### PR TITLE
[server] article 수정일자 res 추가

### DIFF
--- a/packages/server/src/article/article.service.ts
+++ b/packages/server/src/article/article.service.ts
@@ -248,6 +248,7 @@ export class ArticleService {
       .hits(hitCnt)
       .scraps(bookmarkCnt)
       .date(article.date)
+      .updatedAt(article.updatedAt)
       .isBookmark(isBookmark)
       .images(images)
       .build();

--- a/packages/server/src/article/article.service.ts
+++ b/packages/server/src/article/article.service.ts
@@ -282,6 +282,7 @@ export class ArticleService {
           .hits(hitCnt)
           .scraps(bookmarkCnt)
           .date(article.date)
+          .updatedAt(article.updatedAt)
           .build();
       }),
     );

--- a/packages/server/src/article/dtos/article.dto.ts
+++ b/packages/server/src/article/dtos/article.dto.ts
@@ -29,6 +29,7 @@ export class ArticleListInfoDto extends ArticleBaseDto {
 }
 
 export class ArticleResponseDto extends ArticleDetailInfoDto {
+  updatedAt!: Date;
   content!: string;
   isBookmark: boolean;
   images: ImageResponseDto[];

--- a/packages/server/src/article/dtos/article.dto.ts
+++ b/packages/server/src/article/dtos/article.dto.ts
@@ -21,6 +21,7 @@ export class ArticleDto {
 export class ArticleDetailInfoDto extends ArticleBaseDto {
   board: BoardTreeResponseDto;
   date: Date;
+  updatedAt!: Date;
 }
 
 export class ArticleListInfoDto extends ArticleBaseDto {


### PR DESCRIPTION
## 👀 이슈

resolve #492 

## 📌 개요

- 공지사항의 수정 일자 필드가 필요합니다

## 👩‍💻 작업 사항

- 아래 두 API response에 수정일자 필드(updatedAt) 추가 (포맷 : ISO 8601)
  -  article 상세 조회 API
  -  board별 article 리스트 조회 API

## ✅ 참고 사항

<!-- 공유할 내용, 스크린샷 등을 넣어 주세요. -->
