### PR TITLE
[server] Pagination default pageSize NaN 오류

### DIFF
--- a/packages/server/src/commons/page/page.request.ts
+++ b/packages/server/src/commons/page/page.request.ts
@@ -20,22 +20,36 @@ export class PageRequest {
 
   constructor(pageNo: number, pageSize: number) {
     this.pageNo =
-      pageNo < 1 || pageNo === undefined || pageNo === null ? 1 : pageNo;
+      pageNo < 1 ||
+      pageNo === undefined ||
+      pageNo === null ||
+      Number.isNaN(Number(pageNo))
+        ? 1
+        : pageNo;
     this.pageSize =
-      pageSize < 1 || pageSize === undefined || pageSize === null
+      pageSize < 1 ||
+      pageSize === undefined ||
+      pageSize === null ||
+      Number.isNaN(Number(pageSize))
         ? 15
         : pageSize;
   }
 
   getOffset(): number {
-    if (this.pageNo < 1 || this.pageNo === undefined || this.pageNo === null) {
+    if (
+      this.pageNo < 1 ||
+      this.pageNo === undefined ||
+      this.pageNo === null ||
+      Number.isNaN(Number(this.pageNo))
+    ) {
       this.pageNo = 1;
     }
 
     if (
       this.pageSize < 1 ||
       this.pageSize === undefined ||
-      this.pageSize === null
+      this.pageSize === null ||
+      Number.isNaN(Number(this.pageSize))
     ) {
       this.pageSize = 15;
     }
@@ -47,7 +61,8 @@ export class PageRequest {
     if (
       this.pageSize < 1 ||
       this.pageSize === undefined ||
-      this.pageSize === null
+      this.pageSize === null ||
+      Number.isNaN(Number(this.pageSize))
     ) {
       this.pageSize = 15;
     }


### PR DESCRIPTION
## 👀 이슈

resolve #502 

## 📌 개요

페이지네이션이 적용된 일부 API에서 **서로 다른 페이지에서 동일한 결과물을 리턴하는 이슈** 발생

## 👩‍💻 작업 사항

- page.request.ts 수정 
  - input pageNo, pageSize가 NaN인 경우의 처리 추가 

## ✅ 참고 사항

<!-- 공유할 내용, 스크린샷 등을 넣어 주세요. -->
