### PR TITLE
[mobile] 홈 식당 카드에서 아침, 점심, 저녁 판단 기준 변경

### DIFF
--- a/packages/mobile/src/page/Home/Restaurant/Selected/index.tsx
+++ b/packages/mobile/src/page/Home/Restaurant/Selected/index.tsx
@@ -19,10 +19,10 @@ type Props = {
   className?: string;
 };
 
-const getMealTypeIndex = (hour: number) => {
-  if (hour >= 0 && hour < 10) return 0;
-  if (hour >= 10 && hour < 13) return 1;
-  return 2;
+const getMealTimeIndex = (hour: number) => {
+  if (hour >= 0 && hour < 10) return 1;
+  if (hour >= 10 && hour < 13) return 2;
+  return 3;
 };
 
 function Selected({
@@ -46,7 +46,9 @@ function Selected({
     );
 
   const { data, isLoading, error } = allCafeteriaData[target.id - 1];
-  const menuData = data?.data[getMealTypeIndex(today.hour())];
+  const menuData = data?.data.find(({ time }) => {
+    return time === getMealTimeIndex(today.hour());
+  });
 
   if (error || isLoading || !menuData)
     return (


### PR DESCRIPTION
## 👀 이슈

resolve #513

## 📌 개요

유저가 선택한 식당에서 당일 아침, 점심, 저녁 중 하나 이상의 메뉴가 없을 때 제대로 된 메뉴를 보여주지 못하는 문제를 수정했습니다.

## 👩‍💻 작업 사항

- 기존에는 API로부터 받아오는 식단 배열의 index 값으로 아침, 점심, 저녁을 판단했습니다. 이 때문에 메뉴 중 하나가 누락된 경우 무엇이 아침, 점심, 저녁인지 판단할 수 없었습니다.
- 바뀐 방식에서는 현재 시간대에 따라 time index를 1, 2, 3중 하나로 판단하고, API로부터 전달받은 데이터의 `time` 값과 비교하여 표시할 데이터를 결정합니다.
