### PR TITLE
[mobile] 홈 일정 카드 클릭 시 일정 페이지로 이동하는 기능 구현

### DIFF
--- a/packages/mobile/src/page/Home/Schedule/index.tsx
+++ b/packages/mobile/src/page/Home/Schedule/index.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
 
 import classNames from "classnames";
 import dayjs, { Dayjs } from "dayjs";
@@ -18,6 +19,7 @@ type Props = {
 };
 
 function Schedule({ content, startDate, endDate, today }: Props) {
+  const navigate = useNavigate();
   const start = dayjs(startDate);
   const end = endDate ? dayjs(endDate) : null;
   const period = getTimePeriod(start, end, today);
@@ -34,21 +36,27 @@ function Schedule({ content, startDate, endDate, today }: Props) {
     setIsLong(false);
   }, []);
 
+  const handleCardClick = () => {
+    navigate("/calendar");
+  };
+
   return (
-    <BorderBox width={270} height={100} className={$.container}>
-      <div>
-        <span
-          ref={ref}
-          className={classNames($["schedule-name"], {
-            [$["long-schedule-name"]]: isLong,
-          })}
-        >
-          {content}
-        </span>
-        <time className={$.period}>{period}</time>
-      </div>
-      <LongArrow size={8} stroke="#aaa" />
-    </BorderBox>
+    <button type="button" className={$.button} onClick={handleCardClick}>
+      <BorderBox width={270} height={100} className={$.container}>
+        <div>
+          <span
+            ref={ref}
+            className={classNames($["schedule-name"], {
+              [$["long-schedule-name"]]: isLong,
+            })}
+          >
+            {content}
+          </span>
+          <time className={$.period}>{period}</time>
+        </div>
+        <LongArrow size={8} stroke="#aaa" />
+      </BorderBox>
+    </button>
   );
 }
 

--- a/packages/mobile/src/page/Home/Schedule/style.module.scss
+++ b/packages/mobile/src/page/Home/Schedule/style.module.scss
@@ -1,34 +1,38 @@
 @import "src/styles/main.scss";
 @import "@shared/styles/mixin.scss";
 
-.container {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  min-width: 270px;
-  padding: 0 20px;
+.button {
   margin: 0 23px 35px 0;
+  text-align: left;
 
-  .schedule-name {
-    width: 195px;
-    @include ellipsis(2);
-    @include typography(16);
-    font-weight: 500;
-    line-height: 23px;
-    color: $black-80;
-  }
+  .container {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    min-width: 270px;
+    padding: 0 20px;
 
-  .long-schedule-name {
-    font-size: 14px;
-  }
+    .schedule-name {
+      width: 195px;
+      @include ellipsis(2);
+      @include typography(16);
+      font-weight: 500;
+      line-height: 23px;
+      color: $black-80;
+    }
 
-  .period {
-    margin-top: 9px;
-    @include typography(12);
-    color: $black-50;
-  }
+    .long-schedule-name {
+      font-size: 14px;
+    }
 
-  &:last-child {
-    margin-right: 0;
+    .period {
+      margin-top: 9px;
+      @include typography(12);
+      color: $black-50;
+    }
+
+    &:last-child {
+      margin-right: 0;
+    }
   }
 }


### PR DESCRIPTION
## 👀 이슈

resolve #515

## 📌 개요

홈에서 일정 카드를 누르면 일정 페이지(/calendar)로 이동하는 기능을 구현했습니다.

## 👩‍💻 작업 사항

- [x] 홈 일정 카드를 `<button>` 컴포넌트로 감쌈.
- [x] `useNavigate`를 사용하여 유저가 일정 카드를 클릭하면 `/calendar` 페이지로 이동할 수 있도록 함.

## ✅ 참고 사항

- 플럭스에게 홈 일정 카드 오른쪽에 있는 화살표의 기능에 대해 물어봤는데, 해당 일정 카드를 누르면 일정 페이지의 해당 일정으로 이동하는 기능이라고 설명 들었습니다.
- 하지만 홈 페이지에는 오늘의 일정만 뜨고, 일정 페이지도 기본값으로 설정된 날짜가 오늘 날짜이므로 단순히 어떤 일정 카드를 홈에서 누르던 일정 페이지로 이동시키면 플럭스가 말씀하신 기능을 구현할 수 있을 것 같습니다.

![redirect_calendar_demo](https://user-images.githubusercontent.com/71015915/187374766-bd680feb-8028-43f0-bb90-7ff0bc829cac.gif)

