### PR TITLE
[mobile] 홈 날씨 카드에서 Drizzle(이슬비) 상태 대응

### DIFF
--- a/packages/mobile/src/page/Home/Weather/index.tsx
+++ b/packages/mobile/src/page/Home/Weather/index.tsx
@@ -77,6 +77,13 @@ const iconToBackgrounds = [
   },
   {
     backgroundColor: colors.cloudy,
+    icon: <비 />,
+    text: "이슬비",
+    type: "Drizzle",
+    time: "morning",
+  },
+  {
+    backgroundColor: colors.cloudy,
     icon: <안개 />,
     text: "안개",
     type: "Fog",


### PR DESCRIPTION
## 👀 이슈

resolve #518

## 📌 개요

`weathers` API에서 주는 날씨 타입에 `Drizzle`이 포함되어 있지만 프론트에서 처리해주지 않아 아이콘이 표시되지 않았습니다.

## 👩‍💻 작업 사항

- `Drizzle` 상태일 때 비 아이콘을 띄우도록 수정.

## ✅ 참고 사항

- 단순한 PR이므로 셀프 머지하도록 하겠습니다~
