### PR TITLE
[mobile] z-index 순서 수정

### DIFF
--- a/packages/mobile/src/components/molecules/Footer/style.module.scss
+++ b/packages/mobile/src/components/molecules/Footer/style.module.scss
@@ -4,7 +4,7 @@
   left: 0;
   right: 0;
   height: 64px;
-  z-index: 5;
+  z-index: 110;
   display: flex;
   justify-content: space-around;
   align-items: center;

--- a/packages/mobile/src/components/templates/Modal/style.module.scss
+++ b/packages/mobile/src/components/templates/Modal/style.module.scss
@@ -11,7 +11,7 @@
 
 .dimmed {
   @include position(absolute, top 0 left 0 right 0 bottom 0);
-  z-index: 10;
+  z-index: 30;
   background-color: rgba(27, 27, 27, 0.85);
 }
 

--- a/packages/mobile/src/page/Home/Restaurant/Selector/style.module.scss
+++ b/packages/mobile/src/page/Home/Restaurant/Selector/style.module.scss
@@ -3,7 +3,7 @@
 
 .dimmed-box {
   @include position(absolute, top 0 left 0);
-  z-index: 6;
+  z-index: 120;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/packages/mobile/src/page/Home/SuggestionModal/style.module.scss
+++ b/packages/mobile/src/page/Home/SuggestionModal/style.module.scss
@@ -7,7 +7,7 @@
   align-items: center;
   justify-content: center;
   height: 100vh;
-  z-index: 10;
+  z-index: 120;
   background-color: rgba(27, 27, 27, 0.85);
 
   .content-box {

--- a/packages/mobile/src/page/Home/Weather/index.tsx
+++ b/packages/mobile/src/page/Home/Weather/index.tsx
@@ -77,6 +77,13 @@ const iconToBackgrounds = [
   },
   {
     backgroundColor: colors.cloudy,
+    icon: <비 />,
+    text: "이슬비",
+    type: "Drizzle",
+    time: "morning",
+  },
+  {
+    backgroundColor: colors.cloudy,
     icon: <안개 />,
     text: "안개",
     type: "Fog",

--- a/packages/mobile/src/page/Map/style.module.scss
+++ b/packages/mobile/src/page/Map/style.module.scss
@@ -36,7 +36,7 @@ $linkTooltipDistance: 17px;
 
 .wrap {
   position: relative;
-  z-index: 100;
+  z-index: 10;
 }
 
 .balloon {

--- a/packages/mobile/src/page/Notice/Detail/DeepLink/style.module.scss
+++ b/packages/mobile/src/page/Notice/Detail/DeepLink/style.module.scss
@@ -1,9 +1,10 @@
-@import '../../../../styles/main.scss';
+@import "../../../../styles/main.scss";
 
 .deeplink {
   position: fixed;
   left: 50%;
   bottom: 74px;
+  z-index: 20;
   transform: translate(-50%, 0);
   display: flex;
   align-items: center;


### PR DESCRIPTION
## 👀 이슈

resolve #517

## 📌 개요

모바일 페이지 곳곳에서 `position` 속성이 적용된 컴포넌트가 의도와 다르게 가려지는 현상이 있었습니다. 따라서 `z-index` 값을 재조정했습니다.

## 👩‍💻 작업 사항

- `z-index` 값은 10을 단위로 증가시켰습니다.
- 원래 0부터 100 사이에서 순차적으로 증가시킬 생각이었으나, 네이버 지도 푸터의 `z-index` 가 100으로 설정되어 있어, 푸터부터는 110으로 `z-index` 값을 시작했습니다.

### z-index 변경 부분

- 앱 설치 유도 메시지: 20
- dimmed 모달 컴포넌트: 30
- (네이버 지도 푸터): 100
- 푸터: 110
- 기온별 옷차림 모달: 120
- 식당 선택 모달: 120

## ✅ 참고 사항

- @thdwlsgus0 이 말씀하신 문제는 해결되었습니다!
- 서비스 출시 이후 `z-index` 괸련 컨벤션을 정하고 리펙토링 해도 좋을 것 같습니다~
- 분명 `dev`를 머지했는데 머지 커밋과 함께 `dev` 커밋이 같이 보이네요! 다행히 File changed에는 이 브랜치에서 작업한 부분만 보이는 것 같습니다.
