### PR TITLE
[mobile] webview <-> app user-agent 연결

### DIFF
--- a/packages/mobile/src/utils/webview.ts
+++ b/packages/mobile/src/utils/webview.ts
@@ -1,6 +1,8 @@
-import { getUA, isMobile } from "react-device-detect";
+import { getUA, isIOS, isMobile } from "react-device-detect";
 
-const CBNU_ALRAMI_APP_USER_AGENT = "cbnu-alrami-app";
+const CBNU_ALRAMI_APP_USER_AGENT = isIOS
+  ? "cbnu_alrami_ios"
+  : "cbnu_alrami_android";
 
 const isWebView = isMobile && getUA.indexOf(CBNU_ALRAMI_APP_USER_AGENT) > -1;
 const isDev = process.env.NODE_ENV === "development";

--- a/packages/mobile/src/utils/webview.ts
+++ b/packages/mobile/src/utils/webview.ts
@@ -1,10 +1,14 @@
-import { getUA, isIOS, isMobile } from "react-device-detect";
+import { getUA, isMobile } from "react-device-detect";
 
-const CBNU_ALRAMI_APP_USER_AGENT = isIOS
-  ? "cbnu_alrami_ios"
-  : "cbnu_alrami_android";
+const CBNU_ALRAMI_IOS_USER_AGENT = "cbnu_alrami_ios";
+const CBNU_ALRAMI_ANDROID_USER_AGENT = "cbnu_alrami_android";
 
-const isWebView = isMobile && getUA.indexOf(CBNU_ALRAMI_APP_USER_AGENT) > -1;
+const isFromIosApp = getUA.includes(CBNU_ALRAMI_IOS_USER_AGENT);
+const isFromAndroidApp = getUA.includes(CBNU_ALRAMI_ANDROID_USER_AGENT);
+
+const isFromApp = isFromIosApp || isFromAndroidApp;
+
+const isWebView = isMobile && isFromApp;
 const isDev = process.env.NODE_ENV === "development";
 
 export { isWebView, isDev };


### PR DESCRIPTION
## 👀 이슈
resolve #525 

## 📌 개요
- webview 분기 처리를 해준 부분이 있어서 app에서 webview로 `user-agent` 연결이 필요  

## 👩‍💻 기능 설명
- webview `user-agent`를 app의 `user-agent` 값을 추가
- `app`에서 넘겨준 `user-agent`값을 `web`에서 `cbnu_alrami_ios', `cbnu_alrami_android`로 설정 

## ✅ 참고 사항
- `app`과 `web` 화면이 다른 부분이 있어서 같이 살펴보았습니다.
- `app`은 좌측 상단의 화살표 없는 스펙, `web`은 좌측 상단의 화살표가 있는 스펙을 분기처리해주신 것을 확인해서 테스트해보았습니다. 
- 또한 스타도 `web`에서는 보이고 `app`에서는 보이지 않는 부분도 테스트해보았습니다. 
- app
<img width="505" alt="스크린샷 2022-09-01 오전 1 30 01" src="https://user-images.githubusercontent.com/22065725/187730806-2ce3635d-4bcb-48c7-8d7b-d6d09cc5e267.png">
- web
<img width="1780" alt="스크린샷 2022-09-01 오전 1 30 20" src="https://user-images.githubusercontent.com/22065725/187730852-60f91f42-b75a-4a50-8ce7-6d737022931c.png">
