### PR TITLE
[mobile] 모바일 웹 100vh 실제 화면 크기로 맞추기

### DIFF
--- a/packages/mobile/src/App.tsx
+++ b/packages/mobile/src/App.tsx
@@ -6,6 +6,7 @@ import { BrowserRouter, Route, Routes } from "react-router-dom";
 import DeepLink from "src/page/Notice/Detail/DeepLink";
 import Subscription from "src/page/Subscription";
 
+import useWindowSizeDetect from "./hooks/useWindowSizeDetect";
 import "./mobile.scss";
 import Cafeteria from "./page/Cafeteria";
 import Calendar from "./page/Calendar";
@@ -23,6 +24,22 @@ import Preview from "./page/Subscription/Preview";
 
 function App() {
   const [ uuid, setUuid ] = useState("");
+  const [ _, height ] = useWindowSizeDetect();
+
+  const setScreenSize = () => {
+    const vh = window.innerHeight * 0.01;
+    document.documentElement.style.setProperty("--vh", `${vh}px`);
+  };
+
+  useEffect(() => {
+    if (isAndroid || isIOS) {
+      setUuid(JSON.stringify(localStorage.getItem("token")));
+    }
+  }, []);
+
+  useEffect(() => {
+    setScreenSize();
+  }, [ height ]);
 
   const routes = [
     { path: "/notice", element: <Notice /> },
@@ -44,12 +61,6 @@ function App() {
     { path: "/setting/*", element: <SettingRoute /> },
     { path: "/*", element: <Navigate replace to="/home" /> },
   ];
-
-  useEffect(() => {
-    if (isAndroid || isIOS) {
-      setUuid(JSON.stringify(localStorage.getItem("token")));
-    }
-  }, []);
 
   return (
     <BrowserRouter>

--- a/packages/mobile/src/components/templates/FullPageModalTemplate/style.module.scss
+++ b/packages/mobile/src/components/templates/FullPageModalTemplate/style.module.scss
@@ -1,7 +1,7 @@
 @import '../../../styles/main.scss';
 
 .full-modal {
-  height: 100vh;
+  height: calc(var(--vh, 1vh) * 100);
 
   .header {
     position: sticky;

--- a/packages/mobile/src/hooks/useWindowSizeDetect.ts
+++ b/packages/mobile/src/hooks/useWindowSizeDetect.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from "react";
+
+import { throttle } from "src/utils/throttle";
+
+export default function useWindowResize() {
+  const [ size, setSize ] = useState([ 0, 0 ]);
+  const detectSize = () => {
+    return setSize([ window.innerWidth, window.innerHeight ]);
+  };
+  useEffect(() => {
+    window.addEventListener(
+      "resize",
+      throttle(() => {
+        return detectSize();
+      }, 300),
+    );
+
+    return () => {
+      return window.removeEventListener(
+        "resize",
+        throttle(() => {
+          return detectSize();
+        }, 300),
+      );
+    };
+  }, []);
+  return size;
+}

--- a/packages/mobile/src/page/Cafeteria/index.tsx
+++ b/packages/mobile/src/page/Cafeteria/index.tsx
@@ -53,9 +53,11 @@ function Cafeteria() {
       />
 
       <AsyncBoundary
-        suspenseFallback={<SuspenseFallback height="100vh" />}
+        suspenseFallback={
+          <SuspenseFallback height="calc(var(--vh, 1vh) * 100)" />
+        }
         errorFallback={ErrorFallback}
-        fallBackHeight="100vh"
+        fallBackHeight="calc(var(--vh, 1vh) * 100)"
         keys={[ fullDate, selectedMenu ]}
       >
         <CafeteriaBody day={day || 1} {...{ fullDate, selectedMenu }} />

--- a/packages/mobile/src/page/Cafeteria/style.module.scss
+++ b/packages/mobile/src/page/Cafeteria/style.module.scss
@@ -11,7 +11,7 @@
 }
 
 .no-menu {
-  min-height: 100vh;
+  min-height: calc(var(--vh, 1vh) * 100);
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/packages/mobile/src/page/Calendar/CardBox/style.module.scss
+++ b/packages/mobile/src/page/Calendar/CardBox/style.module.scss
@@ -3,14 +3,14 @@
 
 $top-height: 446px;
 $footer-height: 64px;
-$empty-box-height: calc(100vh - $top-height - $footer-height);
+$empty-box-height: calc(var(--vh, 1vh) * 100 - $top-height - $footer-height);
 
 .empty-box {
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  height: calc(100vh - $top-height - $footer-height);
+  height: calc(var(--vh, 1vh) * 100 - $top-height - $footer-height);
 
   .discription {
     @include typography(14);

--- a/packages/mobile/src/page/Home/Restaurant/Selector/style.module.scss
+++ b/packages/mobile/src/page/Home/Restaurant/Selector/style.module.scss
@@ -8,7 +8,7 @@
   align-items: center;
   justify-content: center;
   width: 100vw;
-  height: 100vh;
+  height: calc(var(--vh, 1vh) * 100);
   background-color: rgba(27, 27, 27, 0.85);
 
   .selector {

--- a/packages/mobile/src/page/Home/SuggestionModal/style.module.scss
+++ b/packages/mobile/src/page/Home/SuggestionModal/style.module.scss
@@ -6,7 +6,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  height: 100vh;
+  height: calc(var(--vh, 1vh) * 100);
   z-index: 120;
   background-color: rgba(27, 27, 27, 0.85);
 

--- a/packages/mobile/src/page/Home/style.module.scss
+++ b/packages/mobile/src/page/Home/style.module.scss
@@ -98,6 +98,6 @@
 }
 
 .suggestion-mode {
-  height: 100vh;
+  height: calc(var(--vh, 1vh) * 100);
   overflow-y: hidden;
 }

--- a/packages/mobile/src/page/Map/style.module.scss
+++ b/packages/mobile/src/page/Map/style.module.scss
@@ -8,7 +8,7 @@ $linkTooltipDistance: 17px;
 
 .map {
   width: 100vw;
-  height: 100vh;
+  height: calc(var(--vh, 1vh) * 100);
 }
 
 .place-link {

--- a/packages/mobile/src/page/Notice/Detail/style.module.scss
+++ b/packages/mobile/src/page/Notice/Detail/style.module.scss
@@ -4,7 +4,7 @@
   background: #fff;
 
   .children {
-    height: calc(100vh - 60px);
+    height: calc(var(--vh, 1vh) * 100 - 60px);
     padding: 18px 22px;
     border-top: 1px solid $background-20;
     background: #fff;

--- a/packages/mobile/src/page/Notice/style.module.scss
+++ b/packages/mobile/src/page/Notice/style.module.scss
@@ -1,7 +1,7 @@
 @import "../../styles/main.scss";
 
 .notice {
-  height: calc(100vh - 68px);
+  height: calc(var(--vh, 1vh) * 100 - 68px);
 
   .header-wrapper {
     position: fixed;

--- a/packages/mobile/src/page/Setting/SettingTemplate/style.module.scss
+++ b/packages/mobile/src/page/Setting/SettingTemplate/style.module.scss
@@ -1,5 +1,5 @@
 .setting-template {
-  height: calc(100vh - 60px);
+  height: calc(var(--vh, 1vh) * 100 - 60px);
   display: flex;
   flex-direction: column;
 }

--- a/packages/mobile/src/page/Subscription/style.module.scss
+++ b/packages/mobile/src/page/Subscription/style.module.scss
@@ -33,7 +33,7 @@
 
   .selectors {
     flex: 0 1 auto;
-    height: calc(100vh - 283px);
+    height: calc(var(--vh, 1vh) * 100 - 283px);
     overflow-y: auto;
   }
 }

--- a/packages/mobile/src/utils/throttle.ts
+++ b/packages/mobile/src/utils/throttle.ts
@@ -1,0 +1,15 @@
+export function throttle<T extends unknown[]>(
+  callback: (...args: T) => void,
+  delay: number,
+) {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  return (...args: T) => {
+    if (!timer) {
+      timer = setTimeout(() => {
+        callback(...args);
+        timer = null;
+      }, delay);
+    }
+  };
+}

--- a/packages/shared/src/styles/global.scss
+++ b/packages/shared/src/styles/global.scss
@@ -1,6 +1,9 @@
 @import "./main.scss";
 @import "./font.scss";
 
+:root {
+  --vh: 100%;
+}
 html,
 body,
 div,


### PR DESCRIPTION
## 👀 이슈

resolve #544 

## 📌 개요

모바일 웹 100vh 실제 화면 크기로 맞추기
- 모바일 웹에서는 브라우저 위아래에 있는 주소창, 하단 메뉴 때문에 실제 데스크탑으로 봤을 때의 뷰포트 높이가 달라집니다.
- 이러한 ux를 개선하기 위한 작업입니다.

## 👩‍💻 작업 사항

- [x] useWindowSizeDetect 훅
- [x] throttle함수
- [x] vh -> --vh로 변경

## ✅ 참고 사항
앞으로 style코드에서 vh단위를 사용하실 때, `calc(var(--vh, 1vh)) * 100)`를 사용하시면 됩니다!

### AS-IS

https://user-images.githubusercontent.com/62797441/188324494-7bf377ca-f2db-416c-8b79-a0a8d92d4e09.mov

### TO-BE

https://user-images.githubusercontent.com/62797441/188324502-15410a74-3e0a-4348-a130-92d25dd78ca5.mov

