### PR TITLE
[mobile] 모바일에서 웹에서 보기 구현 

### DIFF
--- a/packages/mobile/src/page/Notice/Detail/Footer/index.tsx
+++ b/packages/mobile/src/page/Notice/Detail/Footer/index.tsx
@@ -19,6 +19,7 @@ type Props = {
 function Footer({ articleId, isBookmark, isCouncil }: Props) {
   const addArticleBookmark = useAddArticleBookmarkMutation(articleId);
   const removeArticleBookmark = useRemoveArticleBookmarkMutation(articleId);
+  const url = window.location.href;
 
   const handleCopy = async () => {
     if (isMobile && baseApp) {
@@ -54,7 +55,11 @@ function Footer({ articleId, isBookmark, isCouncil }: Props) {
           />
         </button>
       )}
-      {!isCouncil && <Internet size={28} stroke="#C3C3C3" />}
+      {!isCouncil && (
+        <a href={url}>
+          <Internet size={28} stroke="#C3C3C3" />
+        </a>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## 👀 이슈
resolve #546 

## 📌 개요
- 모바일 학과공지에서 웹에서 보기 버튼 클릭 시 웹으로 이동하는 것 구현

## 👩‍💻 작업 사항
- `Footer`가 렌더링 될 때, url 상수에 현재 url 정보를 넣어줌
- 웹에서 보기 버튼을 누르면 url 상수에 저장된 웹링크로 이동

## ✅ 참고 사항
- 온전한 `url`로 넘겨주기 위해서 `props`로 이동할 url 정보가 필요할 것 같음
