### PR TITLE
[mobile] Footer 클립보드복사 baseApp not defined

### DIFF
--- a/packages/mobile/src/page/Notice/Detail/Footer/index.tsx
+++ b/packages/mobile/src/page/Notice/Detail/Footer/index.tsx
@@ -4,7 +4,7 @@ import {
 } from "@hooks/api/bookmark";
 import { Internet, Share, Star } from "src/components/atoms/icon";
 import { toastSuccess } from "src/utils/toast";
-import { isWebView } from "src/utils/webview";
+import { isFromApp, isWebView } from "src/utils/webview";
 
 import $ from "./style.module.scss";
 
@@ -20,11 +20,11 @@ function Footer({ url, articleId, isBookmark, isCouncil }: Props) {
   const removeArticleBookmark = useRemoveArticleBookmarkMutation(articleId);
 
   const handleCopy = async () => {
-    // if (isMobile && baseApp) {
-    //   baseApp.postMessage(window.location.href);
-    // } else {
-    //   await navigator.clipboard.writeText(window.location.href);
-    // }
+    if (isFromApp) {
+      baseApp.postMessage(window.location.href);
+    } else {
+      await navigator.clipboard.writeText(window.location.href);
+    }
     return toastSuccess({
       message: "공지사항 링크가 클립보드에 복사되었습니다.",
       style: { marginBottom: "58px" },

--- a/packages/mobile/src/utils/webview.ts
+++ b/packages/mobile/src/utils/webview.ts
@@ -11,4 +11,4 @@ const isFromApp = isFromIosApp || isFromAndroidApp;
 const isWebView = isMobile && isFromApp;
 const isStaging = /stage-mobile\.cmi\.kro\.kr/.test(window.location.href);
 
-export { isWebView, isStaging };
+export { isFromApp, isWebView, isStaging };


### PR DESCRIPTION
## 👀 이슈
resolve #557 

## 📌 개요
- Footer 클립보드복사시 baseApp not defined 에러 발생

## 👩‍💻 작업 사항
- `baseApp` 분기처리 제거
- `isFromApp`값으로 분기처리

## ✅ 참고 사항
- `isWebview`로 분기처리하려고 했으나 앱에서 isMobile이 애뮬레이터에서 true로 나와야할 것 같은데 false로 동작 (애뮬에서만 동작안하는 것 같은데.. 일단 애뮬에서 동작하기 위해서 isFromApp으로 분기처리해주었습니다.) 
- 현재는 app -> front로 넘겨주는 user-agent값인 `isFromApp`값으로 분기처리
   - 문제가 있을 경우 수정해놓겠습니다.
