### PR TITLE
공지사항 상세 페이지 이미지 보이는 경우 추가

### DIFF
--- a/packages/mobile/src/components/atoms/Image/index.tsx
+++ b/packages/mobile/src/components/atoms/Image/index.tsx
@@ -1,0 +1,15 @@
+import classNames from "classnames";
+import { DefaultProps } from "src/type/props";
+
+import $ from "./style.module.scss";
+
+type Props = {
+  src: string;
+  alt: string;
+} & DefaultProps;
+
+function Image({ className, src, alt }: Props) {
+  return <img className={classNames($.image, className)} {...{ src, alt }} />;
+}
+
+export default Image;

--- a/packages/mobile/src/components/atoms/Image/style.module.scss
+++ b/packages/mobile/src/components/atoms/Image/style.module.scss
@@ -1,0 +1,4 @@
+.image {
+  width: 162px;
+  height: 162px;
+}

--- a/packages/mobile/src/components/molecules/ImageList/index.tsx
+++ b/packages/mobile/src/components/molecules/ImageList/index.tsx
@@ -4,13 +4,13 @@ import { Plus } from "@components/atoms/icon";
 
 import $ from "./style.module.scss";
 
-type detailImageType = {
+type DetailImageType = {
   id: number;
   url: string;
 };
 type Props = {
   isMoreContents: boolean;
-  detailImageList: detailImageType[];
+  detailImageList: DetailImageType[];
   name: string;
 };
 

--- a/packages/mobile/src/components/molecules/ImageSlider/index.tsx
+++ b/packages/mobile/src/components/molecules/ImageSlider/index.tsx
@@ -1,0 +1,12 @@
+import classnames from "classnames";
+import { DefaultProps } from "src/type/props";
+
+import $ from "./style.module.scss";
+
+function ImageSlider({ className, children }: DefaultProps) {
+  return (
+    <div className={classnames($["image-slider"], className)}>{children}</div>
+  );
+}
+
+export default ImageSlider;

--- a/packages/mobile/src/components/molecules/ImageSlider/style.module.scss
+++ b/packages/mobile/src/components/molecules/ImageSlider/style.module.scss
@@ -1,0 +1,4 @@
+.image-slider {
+  display: flex;
+  overflow-x: scroll;
+}

--- a/packages/mobile/src/hooks/api/article/index.ts
+++ b/packages/mobile/src/hooks/api/article/index.ts
@@ -54,6 +54,21 @@ export const useNewArticlesQuery = () => {
       getNextPageParam: ({ pagination: { isEnd, pageNumber } }) => {
         return isEnd ? undefined : pageNumber + 1;
       },
+      select: (data) => {
+        const contents = data.pages[0].contents.filter((article) => {
+          return article?.board?.id !== 4;
+        });
+
+        return {
+          ...data,
+          pages: [
+            {
+              pagination: data.pages[0].pagination,
+              contents,
+            },
+          ],
+        };
+      },
     },
   );
 };
@@ -67,6 +82,21 @@ export const usePopularArticlesQuery = () => {
     {
       getNextPageParam: ({ pagination: { isEnd, pageNumber } }) => {
         return isEnd ? undefined : pageNumber + 1;
+      },
+      select: (data) => {
+        const contents = data.pages[0].contents.filter((article) => {
+          return article?.board?.id !== 4;
+        });
+
+        return {
+          ...data,
+          pages: [
+            {
+              pagination: data.pages[0].pagination,
+              contents,
+            },
+          ],
+        };
       },
     },
   );

--- a/packages/mobile/src/hooks/api/article/index.ts
+++ b/packages/mobile/src/hooks/api/article/index.ts
@@ -54,21 +54,6 @@ export const useNewArticlesQuery = () => {
       getNextPageParam: ({ pagination: { isEnd, pageNumber } }) => {
         return isEnd ? undefined : pageNumber + 1;
       },
-      select: (data) => {
-        const contents = data.pages[0].contents.filter((article) => {
-          return article?.board?.id !== 4;
-        });
-
-        return {
-          ...data,
-          pages: [
-            {
-              pagination: data.pages[0].pagination,
-              contents,
-            },
-          ],
-        };
-      },
     },
   );
 };
@@ -82,21 +67,6 @@ export const usePopularArticlesQuery = () => {
     {
       getNextPageParam: ({ pagination: { isEnd, pageNumber } }) => {
         return isEnd ? undefined : pageNumber + 1;
-      },
-      select: (data) => {
-        const contents = data.pages[0].contents.filter((article) => {
-          return article?.board?.id !== 4;
-        });
-
-        return {
-          ...data,
-          pages: [
-            {
-              pagination: data.pages[0].pagination,
-              contents,
-            },
-          ],
-        };
       },
     },
   );

--- a/packages/mobile/src/hooks/api/boardTree/index.ts
+++ b/packages/mobile/src/hooks/api/boardTree/index.ts
@@ -8,6 +8,13 @@ export const useBoardTreesQuery = () => {
     () => {
       return getBoardTrees();
     },
+    {
+      select: (data) => {
+        return data.filter((boardTree) => {
+          return boardTree.id !== 4;
+        });
+      },
+    },
   );
 };
 

--- a/packages/mobile/src/page/Notice/ArticleList/index.tsx
+++ b/packages/mobile/src/page/Notice/ArticleList/index.tsx
@@ -61,11 +61,15 @@ function ArticleList() {
       />
     );
   }
+
   return (
     <div className={$["notification-list"]}>
       {articles?.map((article) => {
         return article.contents.map((articleData) => {
-          const breadcrumb = `${articleData.board.parent?.name} > ${articleData.board.name}`;
+          const parent = articleData.board.parent
+            ? `${articleData.board.parent.name} > `
+            : "";
+          const breadcrumb = `${parent}${articleData.board.name}`;
           const { id, title, date, hits, scraps } = articleData;
           return (
             <Article

--- a/packages/mobile/src/page/Notice/ArticleList/index.tsx
+++ b/packages/mobile/src/page/Notice/ArticleList/index.tsx
@@ -24,6 +24,7 @@ function ArticleList() {
   const target = useSearch({ target: "type" }) || "new";
   const { data, hasNextPage, isFetching, fetchNextPage } = useArticles(target);
   const articles = data?.pages;
+
   const ref = useIntersect(async (entry, observer) => {
     observer.unobserve(entry.target);
     if (hasNextPage && !isFetching) {

--- a/packages/mobile/src/page/Notice/Detail/Footer/index.tsx
+++ b/packages/mobile/src/page/Notice/Detail/Footer/index.tsx
@@ -1,5 +1,3 @@
-import { isMobile } from "react-device-detect";
-
 import {
   useAddArticleBookmarkMutation,
   useRemoveArticleBookmarkMutation,

--- a/packages/mobile/src/page/Notice/Detail/index.tsx
+++ b/packages/mobile/src/page/Notice/Detail/index.tsx
@@ -1,6 +1,8 @@
 import { useParams } from "react-router-dom";
 
 import { LeftArrow } from "@components/atoms/icon";
+import Image from "@components/atoms/Image";
+import ImageSlider from "@components/molecules/ImageSlider";
 import FullPageModalTemplate from "@components/templates/FullPageModalTemplate";
 import { useArticleQuery } from "@hooks/api/article";
 import dayjs from "dayjs";
@@ -18,6 +20,10 @@ function Detail() {
   } = useArticleQuery(Number(articleId)!);
 
   if (!article || error || isLoading) return <></>;
+  const isImageView =
+    (`${article.board.id}`[0] === "3" || `${article.board.id}`[0] === "4") &&
+    article.images.length !== 0;
+
   return (
     <div className={$["notice-detail"]}>
       <FullPageModalTemplate
@@ -33,10 +39,23 @@ function Detail() {
               <span>스크랩&nbsp;{article.scraps}</span>
             </div>
           </div>
-          <div
-            className={$.content}
-            dangerouslySetInnerHTML={{ __html: article.content }}
-          />
+          <div className={$.content}>
+            {isImageView && (
+              <ImageSlider className={$["article-image-wrapper"]}>
+                {article.images.map((image) => {
+                  return (
+                    <Image
+                      className={$["article-image"]}
+                      key={image.id}
+                      src={image.url}
+                      alt="공지사항 이미지"
+                    />
+                  );
+                })}
+              </ImageSlider>
+            )}
+            <div dangerouslySetInnerHTML={{ __html: article.content }} />
+          </div>
         </div>
         <Footer
           url={article.url}

--- a/packages/mobile/src/page/Notice/Detail/style.module.scss
+++ b/packages/mobile/src/page/Notice/Detail/style.module.scss
@@ -24,6 +24,18 @@
 
     .content {
       padding: 18px 0 84px;
+
+      .article-image-wrapper {
+        margin-bottom: 16px;
+
+        .article-image {
+          margin-right: 8px;
+
+          &:last-child {
+            margin-right: 0;
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## 👀 이슈

resolve #559 

## 📌 개요

<!-- PR의 개요를 적어주세요. -->
학생회, 충림이 공지사항의 경우 이미지가 보이게 되서 이 경우 처리

## 👩‍💻 작업 사항

<!-- 작업한 내용을 적어주세요. -->
- 이미지 컴포넌트, 이미지 슬라이더 컴포넌트 생성
- 구독페이지에서 충림이 안보이게 처리
- breadcrumb에서 부모 board name없을 경우 처리 

## ✅ 참고 사항

<!-- 공유할 내용, 스크린샷 등을 넣어 주세요. -->
<img width="394" alt="image" src="https://user-images.githubusercontent.com/38103082/194332452-5bbe27d6-e8b2-41d8-acf2-0a679f3a9cb0.png">
<img width="386" alt="image" src="https://user-images.githubusercontent.com/38103082/194332173-c86e7587-0b0f-445a-b297-02706d158034.png">
<img width="390" alt="image" src="https://user-images.githubusercontent.com/38103082/194332272-818d5657-504f-449a-9d80-14dc12329b05.png">
