### PR TITLE
[server] 학교 건물 조회 API `area`(구역) query로 받기

### DIFF
--- a/packages/server2/src/place/place.controller.ts
+++ b/packages/server2/src/place/place.controller.ts
@@ -1,5 +1,10 @@
-import { Controller, Get, Param } from "@nestjs/common";
-import { ApiOkResponse, ApiOperation, ApiTags } from "@nestjs/swagger";
+import { Controller, Get, Param, Query } from "@nestjs/common";
+import {
+  ApiOkResponse,
+  ApiOperation,
+  ApiQuery,
+  ApiTags,
+} from "@nestjs/swagger";
 import { SchoolArea } from "src/school/school.constant";
 
 import { PlaceSchoolDto } from "./dto/response-place.dto";
@@ -13,10 +18,16 @@ export class PlaceController {
   @ApiOperation({
     summary: "학교 건물 조회",
   })
+  @ApiQuery({
+    name: "area",
+    required: false,
+    description: "구역(S,N,E)",
+    schema: { enum: Object.values(SchoolArea) },
+  })
   @ApiOkResponse({ type: PlaceSchoolDto, isArray: true })
   @Get("school")
-  findSchool() {
-    return this.placeService.findSchool();
+  findSchool(@Query("area") area?: SchoolArea) {
+    return this.placeService.findSchool(area);
   }
 
   @ApiOperation({
@@ -26,21 +37,5 @@ export class PlaceController {
   @Get("school/:id")
   findOneSchool(@Param("id") id: number) {
     return this.placeService.findOneSchool(id);
-  }
-
-  @ApiOperation({
-    summary: "구역으로 학교 건물 조회",
-    parameters: [
-      {
-        name: "area",
-        in: "path",
-        schema: { enum: Object.values(SchoolArea) },
-      },
-    ],
-  })
-  @ApiOkResponse({ type: PlaceSchoolDto, isArray: true })
-  @Get("school/:area")
-  findSchoolByArea(@Param("area") area?: SchoolArea) {
-    return this.placeService.findSchool(area);
   }
 }

--- a/packages/shared/src/swagger-api/generated/services/PlaceApiService.ts
+++ b/packages/shared/src/swagger-api/generated/services/PlaceApiService.ts
@@ -14,10 +14,20 @@ export class PlaceApiService {
      * @returns PlaceSchoolDto
      * @throws ApiError
      */
-    public static placeControllerFindSchool(): CancelablePromise<Array<PlaceSchoolDto>> {
+    public static placeControllerFindSchool({
+        area,
+    }: {
+        /**
+         * 구역(S,N,E)
+         */
+        area?: 'N' | 'S' | 'E',
+    }): CancelablePromise<Array<PlaceSchoolDto>> {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/place/school',
+            query: {
+                'area': area,
+            },
         });
     }
 
@@ -36,25 +46,6 @@ export class PlaceApiService {
             url: '/place/school/{id}',
             path: {
                 'id': id,
-            },
-        });
-    }
-
-    /**
-     * 구역으로 학교 건물 조회
-     * @returns PlaceSchoolDto
-     * @throws ApiError
-     */
-    public static placeControllerFindSchoolByArea({
-        area,
-    }: {
-        area: string,
-    }): CancelablePromise<Array<PlaceSchoolDto>> {
-        return __request(OpenAPI, {
-            method: 'GET',
-            url: '/place/school/{area}',
-            path: {
-                'area': area,
             },
         });
     }


### PR DESCRIPTION
## 👀 이슈

area가 pathParam이어서 건물상세 API의 id로 가고있었음

## 👩‍💻 작업 사항

학교 건물 목록 조회 API에서 area를 query param으로 받도록 수정

![image](https://user-images.githubusercontent.com/49256790/216819118-949ad5f5-88dd-4a4e-a0a1-df1c47d9fe3d.png)

## ✅ 참고 사항

<!-- 공유할 내용, 스크린샷 등을 넣어 주세요. -->
