### PR TITLE
[server] http 에러 필터링에 메시지랑 스택정보 추가

### DIFF
--- a/packages/server2/src/common/http-exception-filter.ts
+++ b/packages/server2/src/common/http-exception-filter.ts
@@ -6,6 +6,8 @@ import {
 } from "@nestjs/common";
 import { Request, Response } from "express";
 
+import { isDev } from "./util/utils";
+
 @Catch(HttpException)
 export class HttpExceptionFilter implements ExceptionFilter {
   catch(exception: HttpException, host: ArgumentsHost) {
@@ -18,6 +20,8 @@ export class HttpExceptionFilter implements ExceptionFilter {
       statusCode: status,
       timestamp: new Date().toISOString(),
       path: request.url,
+      message: exception.message,
+      ...(isDev && { log: { stack: exception.stack } }),
     });
   }
 }

--- a/packages/server2/src/common/util/utils.ts
+++ b/packages/server2/src/common/util/utils.ts
@@ -1,0 +1,3 @@
+import configuration from "src/config/configuration";
+
+export const isDev = configuration.server.env === "dev";

--- a/packages/server2/src/config/configuration.help.ts
+++ b/packages/server2/src/config/configuration.help.ts
@@ -2,6 +2,7 @@ import { Configutation } from "./types";
 
 const configuration: Configutation = {
   server: {
+    env: "dev",
     host: "",
     port: 0,
   },

--- a/packages/server2/src/config/types.ts
+++ b/packages/server2/src/config/types.ts
@@ -1,5 +1,6 @@
 export type Configutation = {
   server: {
+    env: "dev" | "production";
     host: string;
     port: number;
   };


### PR DESCRIPTION
## 👀 이슈

resolve https://github.com/CMI-OSS/cbnu-alrami/issues/616

http response로 에러 메시지가 나오지 않음

## 👩‍💻 작업 사항

에러 발생시 response로 메시지가 노출되고, 개발환경에서는 stack 정보 까지 노출

![image](https://user-images.githubusercontent.com/49256790/217664238-917ddd0b-d4c3-492f-8e38-f269c1571903.png)


## ✅ 참고 사항

<!-- 공유할 내용, 스크린샷 등을 넣어 주세요. -->
