### PR TITLE
[server] 스케줄 시작시간 검사 로직 `Between`으로 변경

### DIFF
--- a/packages/server2/src/schedule/schedule.service.ts
+++ b/packages/server2/src/schedule/schedule.service.ts
@@ -5,7 +5,7 @@ import { InjectRepository } from "@nestjs/typeorm";
 import { firstValueFrom } from "rxjs";
 import configuration from "src/config/configuration";
 import { User } from "src/user/entities/user.entity";
-import { LessThanOrEqual, MoreThanOrEqual, Repository } from "typeorm";
+import { Between, MoreThanOrEqual, Repository } from "typeorm";
 
 import { CreateScheduleDto } from "./dto/create-schedule.dto";
 import { GetScheduleDto } from "./dto/get-schedule.dto";
@@ -78,7 +78,9 @@ export class ScheduleService {
     return this.scheduleRepository.find({
       where: {
         startDateTime: MoreThanOrEqual(startDateTime),
-        ...(endDateTime && { startDateTime: LessThanOrEqual(endDateTime) }),
+        ...(endDateTime && {
+          startDateTime: Between(startDateTime, endDateTime),
+        }),
       },
       order: {
         startDateTime: "ASC",


### PR DESCRIPTION
## 👀 이슈

qeury.startDateTime 이전의 스케줄까지 불러와지는 현상

## 👩‍💻 작업 사항

`qeury.startDateTime` 와 `qeury.endDateTime`둘 다 있는 경우 `Between` 으로 검사

![image](https://user-images.githubusercontent.com/49256790/217802885-68a74501-728c-46a9-8a7f-306980762e1c.png)


## ✅ 참고 사항

<!-- 공유할 내용, 스크린샷 등을 넣어 주세요. -->
