### PR TITLE
[mobile] 홈 날씨 카드에서 온도를 소수점 첫째 자리까지만 보여주기

### DIFF
--- a/packages/mobile/src/hooks/api/weather/index.ts
+++ b/packages/mobile/src/hooks/api/weather/index.ts
@@ -2,8 +2,22 @@ import { useCoreQuery } from "@hooks/api/core";
 import { WeatherApiService } from "@shared/swagger-api/generated";
 import { queryKey } from "src/consts/react-query";
 
+const roundToOneDecimal = (num?: number)  => {
+  if (!num) return 0;
+  return Math.round(num * 10) / 10;
+}
+
 export const useWeathersQuery = () => {
   return useCoreQuery(queryKey.weathers, () => {
     return WeatherApiService.weatherControllerGetWeather();
+  }, {
+    select: (data) => {
+      return {
+        ...data,
+        currentTemp: roundToOneDecimal(data.currentTemp),
+        maxTemp: roundToOneDecimal(data.maxTemp),
+        minTemp: roundToOneDecimal(data.minTemp),
+      }
+    }
   });
 };


### PR DESCRIPTION
## 👀 이슈

resolve #644

## 👩‍💻 작업 사항

- 충림이 모바일 홈 날씨 카드에서 현재 온도, 최저 온도, 최고 온도를 각각 소수점 한 자리까지 보여주도록 했습니다.
- 날씨 정보를 받아오는 쿼리 훅의 `select` 옵션을 사용하여 컴포넌트단에서 소수점 한 자리로 반올림된 날씨 정보를 바로 사용할 수 있도록 했습니다.

## ✅ 참고 사항

<img width="363" alt="image" src="https://user-images.githubusercontent.com/71015915/220093229-49dca5da-62d6-4d9e-a4f9-eabd2e9e6504.png">

