### PR TITLE
[Mobile] DeferredComponent로 로딩 UX 개선하기

### DIFF
--- a/packages/mobile/src/components/atoms/DeferredComponent/index.tsx
+++ b/packages/mobile/src/components/atoms/DeferredComponent/index.tsx
@@ -1,0 +1,23 @@
+import { PropsWithChildren, useEffect, useState } from "react";
+
+import { DEFFERRED_LOADING_TIME } from "src/constants";
+
+function DeferredComponent({ children }: PropsWithChildren) {
+  const [ isDeferred, setIsDeferred ] = useState(false);
+
+  useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      setIsDeferred(true);
+    }, DEFFERRED_LOADING_TIME);
+    return () => {
+      return clearTimeout(timeoutId);
+    };
+  }, []);
+
+  if (!isDeferred) {
+    return null;
+  }
+  return <>{children}</>;
+}
+
+export default DeferredComponent;

--- a/packages/mobile/src/components/atoms/SuspenseFallback/index.tsx
+++ b/packages/mobile/src/components/atoms/SuspenseFallback/index.tsx
@@ -1,3 +1,4 @@
+import DeferredComponent from "../DeferredComponent";
 import Loading from "../Loading";
 import $ from "./style.module.scss";
 
@@ -8,9 +9,11 @@ type Props = {
 function SuspenseFallback(props: Props) {
   const { height } = props;
   return (
-    <div className={$["suspense-fallback"]} style={{ height }}>
-      <Loading width={64} borderWidth={4} color="#D66D6E" />
-    </div>
+    <DeferredComponent>
+      <div className={$["suspense-fallback"]} style={{ height }}>
+        <Loading width={64} borderWidth={4} color="#D66D6E" />
+      </div>
+    </DeferredComponent>
   );
 }
 

--- a/packages/mobile/src/constants.ts
+++ b/packages/mobile/src/constants.ts
@@ -36,3 +36,5 @@ export const BASE_HEAD_META = {
   type: "website",
   image: "/src/assets/favicon/favicon-16x16.png",
 };
+
+export const DEFFERRED_LOADING_TIME = 1000;


### PR DESCRIPTION
## 👀 이슈

resolve #646 

## 👩‍💻 작업 사항

- [x] DefferedComponent추가

## ✅ 참고 사항

너무 잦은 로딩 컴포넌트는 UX를 해친다고 생각했고 이를 증명하는 자료 또한 있습니다. 그리하여 `useTransition`을 사용하여 [동시적인 UI 패턴](https://17.reactjs.org/docs/concurrent-mode-patterns.html)을  도입해보려 했지만 react-query에서 `useTransition`을 사용할 수 있는 방법을 찾지못해 아래 참고자료를 통해 DeferredComponent를 추가하였습니다.

`setTimeout`을 사용하였기 때문에 로딩 시간이 1초 이상 지나게 되면 정상적으로 로딩 컴포넌트가 나타납니다.
Suspense는 Suspense의 children컴포넌트가 suspended상태(data fetching의 loading 상태)가 끝나면 정상적인 컴포넌트를 렌더링합니다. 따라서 deferred time(1초)이 로딩 시간보다 길더라도 `로딩 시간이 1초보다 느린 경우에만 로딩 컴포넌트를 렌더링하고 로딩이 끝나면 정상 컴포넌트를 표시`할 수 있습니다.

`useTransition`은 배포를 마치고 나서 조금 더 연구하며 도입해보도록 하겠습니다.

### 데모
https://user-images.githubusercontent.com/62797441/221409845-79485852-52f3-418f-a743-d9030eea3ee8.mov

### 참고자료
- https://tech.kakaopay.com/post/skeleton-ui-idea/
- https://17.reactjs.org/docs/concurrent-mode-patterns.html