### PR TITLE
[mobile] 홈 식단 카드 스타일 오류 수정

### DIFF
--- a/packages/mobile/src/page/Home/Restaurant/EmptyCafeteria/style.module.scss
+++ b/packages/mobile/src/page/Home/Restaurant/EmptyCafeteria/style.module.scss
@@ -12,6 +12,7 @@
       @include typography(16);
       margin-right: 10px;
       font-weight: 500;
+      color: $black-100;
     }
   }
 

--- a/packages/mobile/src/page/Home/Restaurant/Selected/style.module.scss
+++ b/packages/mobile/src/page/Home/Restaurant/Selected/style.module.scss
@@ -18,6 +18,7 @@
         @include typography(16);
         line-height: 25px;
         font-weight: 500;
+        color: $black-100;
       }
 
       > button {

--- a/packages/mobile/src/page/Home/Restaurant/Selector/style.module.scss
+++ b/packages/mobile/src/page/Home/Restaurant/Selector/style.module.scss
@@ -5,7 +5,8 @@
   align-items: center;
   justify-content: center;
   width: 100vw;
-  height: calc(var(--vh, 1vh) * 100);
+  min-height: calc(var(--vh, 1vh) * 100);
+  padding-top: 40px;
   background-color: rgba(27, 27, 27, 0.85);
 
   .selector {


### PR DESCRIPTION
## 👀 이슈

**크기가 작은 PR이라 셀프 머지하겠습니다**

resolve #681

## 👩‍💻 작업 사항

- [x] IOS safari에서 홈 식단 카드 제목이 파랗게 보이는 이슈 수정.
- [x] 화면 세로 길이가 짧은 기기에서 식당 선택 모달이 정상적으로 표시되지 않는 이슈 수정. 

## ✅ 참고 사항

### 🐞 수정전

<img width="342" alt="스크린샷 2023-03-06 오후 9 38 28" src="https://user-images.githubusercontent.com/71015915/223114446-cb6e370c-eb4d-4ce9-85da-2c362a95b248.png">

![Simulator Screen Shot - iPhone SE (3rd generation) - 2023-03-06 at 21 38 39](https://user-images.githubusercontent.com/71015915/223114830-9a187533-065c-48ec-bba3-8a36b08ba53d.png)

(이 상태에서 정상적인 스크롤이 되지 않습니다)

###  🔨 수정후

<img width="357" alt="스크린샷 2023-03-06 오후 9 38 56" src="https://user-images.githubusercontent.com/71015915/223114923-4e380155-e3a2-40c4-9471-104481b99473.png">

![Simulator Screen Shot - iPhone SE (3rd generation) - 2023-03-06 at 21 39 01](https://user-images.githubusercontent.com/71015915/223114947-04f3df59-0301-4295-a4dd-b58b2c27a792.png)

(`margin-top`이 유지된 상태로 표시됩니다)

![Simulator Screen Shot - iPhone SE (3rd generation) - 2023-03-06 at 21 39 08](https://user-images.githubusercontent.com/71015915/223114952-df67d322-9f4d-4d99-b3e2-6aff5ca4e9ce.png)

(제일 끝까지 정상적으로 스크롤됩니다)
