### PR TITLE
[mobile] 특정 현재 온도에서 옷차림 추천이 작동하지 않는 문제 수정

### DIFF
--- a/packages/mobile/src/page/Home/SuggestionModal/index.tsx
+++ b/packages/mobile/src/page/Home/SuggestionModal/index.tsx
@@ -59,15 +59,16 @@ function compareTemperature(
   currentTemperature?: number,
 ) {
   if (!currentTemperature) return false;
+  const currentTemperatureInt = Math.round(currentTemperature);
   if (!minTemp) {
-    if (maxTemp! >= currentTemperature) return true;
+    if (maxTemp! >= currentTemperatureInt) return true;
     return false;
   }
   if (!maxTemp) {
-    if (minTemp! <= currentTemperature) return true;
+    if (minTemp! <= currentTemperatureInt) return true;
     return false;
   }
-  return minTemp <= currentTemperature && currentTemperature <= maxTemp;
+  return minTemp <= currentTemperatureInt && currentTemperatureInt <= maxTemp;
 }
 
 function SuggestionModal({ currentTemperature, onClick }: Props) {


### PR DESCRIPTION
## 👀 이슈

**크기가 작은 PR이므로 셀프 머지하겠습니다.**

resolve #683

## 👩‍💻 작업 사항

현재 온도가 추천 온도 구간 사이에 위치할 때(예를 들어 5 ~ 8도, 9 ~ 11도 구간이 있을 때 현재 온도가 8.5도인 경우) 옷차림 추천이 작동하지 않는 문제를 수정했습니다.

- [x] 현재 온도를 반올림/반내림하여 계산하기
<!-- 작업한 내용을 적어주세요. -->
