### PR TITLE
[mobile] 캘린더 페이지 디자인 가이드 수정에 따른 스타일 변경

### DIFF
--- a/packages/mobile/src/page/Calendar/ArrowButton/index.tsx
+++ b/packages/mobile/src/page/Calendar/ArrowButton/index.tsx
@@ -15,9 +15,9 @@ function ArrowButton({ direction, onClick }: Props) {
       aria-label={`${direction === "left" ? "이전" : "다음"}으로 이동`}
     >
       {direction === "left" ? (
-        <Arrow size={6} stroke="#aaa" />
+        <Arrow size={6} stroke="#5e5e5e" />
       ) : (
-        <Arrow size={6} stroke="#aaa" style={{ transform: "rotate(180deg)" }} />
+        <Arrow size={6} stroke="#5e5e5e" style={{ transform: "rotate(180deg)" }} />
       )}
     </button>
   );

--- a/packages/mobile/src/page/Calendar/CollegeCard/index.tsx
+++ b/packages/mobile/src/page/Calendar/CollegeCard/index.tsx
@@ -47,7 +47,7 @@ function CollegeCard(props: Props) {
         {isBookmarked ? (
           <Star size={20} fill="#d66d6e" stroke="#d66d6e" />
         ) : (
-          <Star size={20} stroke="#c3c3c3" />
+          <Star size={20} stroke="#5e5e5e" />
         )}
       </button>
     </BorderBox>


### PR DESCRIPTION
## 👀 이슈

**작업량이 많지 않아 셀프 어프루브로 머지하겠습니다.**

resolve #732

## 👩‍💻 작업 사항

- [x] 캘린더 헤더의 연도 넘기는 버튼 색깔 `black40` -> `black60`
- [x] 캘린더 하단의 일정 카드 즐겨찾기 버튼 색깔 `black20` -> `black60`

<!-- 작업한 내용을 적어주세요. -->

## ✅ 참고 사항
### 수정전

<img width="191" alt="스크린샷 2023-03-25 오후 2 37 08" src="https://user-images.githubusercontent.com/71015915/227699232-222dc643-7fdc-40f3-9161-594416c34aca.png">
<img width="367" alt="스크린샷 2023-03-25 오후 2 38 20" src="https://user-images.githubusercontent.com/71015915/227699234-6b02b96a-c9e8-4989-be40-1a43056c423f.png">

### 수정후
<img width="183" alt="스크린샷 2023-03-25 오후 2 37 15" src="https://user-images.githubusercontent.com/71015915/227699240-693ff100-eb4a-4a7e-96cc-03bac8468ef7.png">
<img width="368" alt="스크린샷 2023-03-25 오후 2 38 12" src="https://user-images.githubusercontent.com/71015915/227699241-dc67d702-de60-4137-b993-b2183096d467.png">


<!-- 공유할 내용, 스크린샷 등을 넣어 주세요. -->
