### PR TITLE
[mobile/server] native에서 이미지 다운로드 및 외부 URL 이동가능 하도록 baseApp 프로토콜 수정

### DIFF
--- a/packages/mobile/src/components/atoms/ShareButton/index.tsx
+++ b/packages/mobile/src/components/atoms/ShareButton/index.tsx
@@ -18,7 +18,12 @@ export default function ShareButton({
 }: Props) {
   const handleCopyClick = () => {
     if (isFromApp) {
-      baseApp.postMessage(window.location.href);
+      baseApp.postMessage(
+        JSON.stringify({
+          action: "copy",
+          url: window.location.href,
+        }),
+      );
     } else {
       navigator.clipboard.writeText(window.location.href);
     }

--- a/packages/mobile/src/components/shared/ImageModal/index.tsx
+++ b/packages/mobile/src/components/shared/ImageModal/index.tsx
@@ -1,10 +1,9 @@
-import React from "react";
-
 import { Close, Download } from "@components/atoms/icon";
 import SwiperImage from "@components/molecules/SwiperImage";
 import { Image as ImageType } from "@shared/swagger-api/generated";
 import classnames from "classnames";
 import { DefaultProps } from "src/type/props";
+import { isFromApp } from "src/utils/webview";
 
 import $ from "./style.module.scss";
 
@@ -19,18 +18,29 @@ function ImageModal({ order, setOrder, onClose, images }: Props) {
   // TODO: 백엔드 수정 후 확인필요
   const handleDownloadClick = async () => {
     const { id, url } = images[order - 1];
-    const response = await fetch(url);
-    const file = await response.blob();
-    const downloadUrl = window.URL.createObjectURL(file);
-    const link = document.createElement("a");
-    document.body.appendChild(link);
-    link.download = `충림이이미지${id}`;
-    link.href = downloadUrl;
 
-    link.click();
+    if (isFromApp) {
+      baseApp.postMessage(
+        JSON.stringify({
+          action: "image",
+          url,
+          preview: false,
+        }),
+      );
+    } else {
+      const response = await fetch(url);
+      const file = await response.blob();
+      const downloadUrl = window.URL.createObjectURL(file);
+      const link = document.createElement("a");
+      document.body.appendChild(link);
+      link.download = `충림이이미지${id}`;
+      link.href = downloadUrl;
 
-    document.body.removeChild(link);
-    window.URL.revokeObjectURL(downloadUrl);
+      link.click();
+
+      document.body.removeChild(link);
+      window.URL.revokeObjectURL(downloadUrl);
+    }
   };
 
   return (

--- a/packages/mobile/src/page/Article/components/Footer/index.tsx
+++ b/packages/mobile/src/page/Article/components/Footer/index.tsx
@@ -4,6 +4,7 @@ import {
   usePostBookmarkArticleMutation,
 } from "@hooks/api/article";
 import ShareButton from "src/components/atoms/ShareButton";
+import { isFromApp } from "src/utils/webview";
 
 import $ from "./style.module.scss";
 
@@ -29,7 +30,11 @@ function ArticleFooter({ articleId, isBookmark, isUser, url }: Props) {
   };
 
   const handleClickUrl = () => {
-    window.open(url);
+    if (isFromApp) {
+      baseApp.postMessage(JSON.stringify({ action: "navigate", url }));
+    } else {
+      window.open(url);
+    }
   };
 
   return (

--- a/packages/mobile/src/type/global.d.ts
+++ b/packages/mobile/src/type/global.d.ts
@@ -12,5 +12,5 @@ declare module "*.scss" {
 }
 
 declare namespace baseApp {
-  function postMessage(url: string);
+  function postMessage(message: string);
 }

--- a/packages/server/src/fcm/fcm.service.ts
+++ b/packages/server/src/fcm/fcm.service.ts
@@ -72,6 +72,7 @@ export class FcmService {
       if (fcmToken)
         this.sendNotice(fcmToken, notification, {
           articleId: article.id.toString(),
+          url: `https://dev-mobile.cmi.kro.kr/article/detail/${  article.id}`,
         });
     });
   }


### PR DESCRIPTION
## 👀 이슈

native에서 이미지 다운로드 및 외부 URL 이동가능 하도록 baseApp 프로토콜 수정

## 👩‍💻 작업 사항

### mobile
- baseApp으로 messaget시 전달시
 - action(필수): copy(클립보드 복사), image(이미지 다운로드), navigate(외부URL 이동)
 - url(필수) - 대상 URL 

### server
FCM 알림 전달시에 공지사항 주소가 포함된 URL전체로 전송

