### PR TITLE
[mobile] 모바일 홈 좌우 마진 다른 것 수정

### DIFF
--- a/packages/mobile/src/page/Home/style.module.scss
+++ b/packages/mobile/src/page/Home/style.module.scss
@@ -1,5 +1,5 @@
 .home {
-  padding: 34px 25px 100px 35px;
+  padding: 34px 24px 100px 24px;
   background: #f5f6fa;
 }
 


### PR DESCRIPTION
## 👀 이슈
**간단한 스타일 수정이라 바로 머지하겠습니다.**

resolve #766 

## 👩‍💻 작업 사항

- [x] 홈 메인 컨테이너 스타일 속성에서 좌우 패딩값을 `24px`로 일치시키기.
<!-- 작업한 내용을 적어주세요. -->

## ✅ 참고 사항
<img width="378" alt="image" src="https://user-images.githubusercontent.com/71015915/228429325-916a6316-536d-45c5-9c0d-07af80571c9f.png">
<img width="251" alt="image" src="https://user-images.githubusercontent.com/71015915/228429341-86d7212b-8bae-450d-ae28-418b8923ec73.png">

<!-- 공유할 내용, 스크린샷 등을 넣어 주세요. -->
