### PR TITLE
[mobile] ios 14에서 height 0 동작하는 이슈 해결

### DIFF
--- a/packages/mobile/src/components/atoms/NavigationLink/style.module.scss
+++ b/packages/mobile/src/components/atoms/NavigationLink/style.module.scss
@@ -3,11 +3,13 @@
   flex-direction: column;
   justify-content: center;
   padding: 10px;
+  height: 64px;
   align-items: center;
-  font-size: 10px;
 
   .label {
-    margin-top: 6px;
+    font-size: 12px;
+    line-height: 12px;
+    margin-top: 10px;
     color: $black-60;
   }
 }


### PR DESCRIPTION
## 👀 이슈
resolve #770 

## 👩‍💻 작업 사항
- ios 14에서 height 0으로 변하는 이슈 수정
- `safari preview`를 통해서 dev 도메인으로 요소 테스트 진행 

## ✅ 참고 사항
- font-size와 margin, line-height는 피그마를 기반으로 수정하였습니다. 참고 부탁드려요~!

![KakaoTalk_Photo_2023-04-02-16-14-07](https://user-images.githubusercontent.com/22065725/229338242-07d89787-f065-4f40-9dc0-44aeb25bfebb.png)
