### PR TITLE
[mobile] 학사일정 > `MOCK_UUID`를 제거하고 getUuid 함수 호출로 변경

### DIFF
--- a/packages/mobile/src/hooks/api/schedule/index.ts
+++ b/packages/mobile/src/hooks/api/schedule/index.ts
@@ -8,6 +8,7 @@ import dayjs, { Dayjs } from "dayjs";
 import { queryKey } from "src/consts/react-query";
 import { queryClient } from "src/main";
 import { GetParams } from "src/type/utils";
+import { getUuid } from "src/utils/storage";
 
 export type FormattedSchedule = Omit<
   Schedule,
@@ -83,16 +84,12 @@ export const useTodaySchedulesQuery = (
   );
 };
 
-export const useBookmarkSchedulesQuery = (
-  uuid: GetParams<
-    typeof ScheduleApiService.scheduleControllerFindBookmarkSchedule
-  >["uuid"],
-) => {
+export const useBookmarkSchedulesQuery = () => {
   return useCoreQuery<Schedule[], FormattedSchedule[]>(
     queryKey.bookmarkSchedules,
     () => {
       return ScheduleApiService.scheduleControllerFindBookmarkSchedule({
-        uuid,
+        uuid: getUuid(),
       });
     },
     {

--- a/packages/mobile/src/page/Calendar/CollegeCard/index.tsx
+++ b/packages/mobile/src/page/Calendar/CollegeCard/index.tsx
@@ -10,8 +10,8 @@ import classNames from "classnames";
 import { Dayjs } from "dayjs";
 import { DefaultProps } from "src/type/props";
 import { getDatePeriod } from "src/utils/calendarTools";
+import { getUuid } from "src/utils/storage";
 
-import { MOCK_UUID } from "..";
 import $ from "./style.module.scss";
 
 type Props = {
@@ -33,10 +33,10 @@ function CollegeCard(props: Props) {
 
   const handleStarClick = () => {
     if (isBookmarked) {
-      removeScheduleBookmark.mutate({ id, uuid: MOCK_UUID });
+      removeScheduleBookmark.mutate({ id, uuid: getUuid() });
       return;
     }
-    addScheduleBookmark.mutate({ id, uuid: MOCK_UUID });
+    addScheduleBookmark.mutate({ id, uuid: getUuid() });
   };
 
   return (

--- a/packages/mobile/src/page/Calendar/index.tsx
+++ b/packages/mobile/src/page/Calendar/index.tsx
@@ -16,8 +16,6 @@ import caledarReducer from "./calendarReducer";
 import $ from "./style.module.scss";
 import useSelectedDate from "./useSelectedDate";
 
-export const MOCK_UUID = "1111";
-
 export type ScheduleType = "all" | "bookmark";
 
 export type DateMap = {
@@ -36,7 +34,7 @@ function Calendar() {
   const [ selectedDate, setSelectedDate ] = useSelectedDate(today, year, month);
 
   const { data: allSchedules } = useFullSchedulesQuery(year);
-  const { data: bookmarkedSchedules } = useBookmarkSchedulesQuery(MOCK_UUID);
+  const { data: bookmarkedSchedules } = useBookmarkSchedulesQuery();
   if (!bookmarkedSchedules || !allSchedules) return <div>없음</div>;
 
   const allScheduleMap = getCalendarMap(year, month, allSchedules);


### PR DESCRIPTION
## 👀 이슈

resolve #780 

## 👩‍💻 작업 사항

- 학사일정쪽에 `MOCK_UUID`를 사용하고 있던곳이 있어서 제거하고 `getUuid`함수 호출로 변경하였습니다
 

## ✅ 참고 사항
![image](https://user-images.githubusercontent.com/49256790/229354271-130b96d0-17ea-4f73-9ca3-6f5e70d6283c.png)

<!-- 공유할 내용, 스크린샷 등을 넣어 주세요. -->
