### PR TITLE
[mobile] 홈 옷차림 추천 모달 및 식단 카드 색깔 접근성 수정

### DIFF
--- a/packages/mobile/src/page/Home/Restaurant/Selected/index.tsx
+++ b/packages/mobile/src/page/Home/Restaurant/Selected/index.tsx
@@ -59,7 +59,7 @@ function Selected(props: Props) {
             aria-label="대표 식당 변경하기"
             onClick={onClick}
           >
-            <Write stroke="#aaa" size={12} />
+            <Write stroke="#5E5E5E" size={12} />
           </button>
         </div>
         <span className={$.time}>{mealPeriod}</span>

--- a/packages/mobile/src/page/Home/Restaurant/Selected/style.module.scss
+++ b/packages/mobile/src/page/Home/Restaurant/Selected/style.module.scss
@@ -29,7 +29,7 @@
     .time {
       @include typography(14);
       line-height: 30px;
-      color: $black-40;
+      color: $black-50;
     }
   }
 
@@ -48,7 +48,7 @@
     .empty-menu {
       @include typography(13);
       margin: 39px 0 27px;
-      color: $black-40;
+      color: $black-50;
     }
   }
 }

--- a/packages/mobile/src/page/Home/SuggestionModal/index.tsx
+++ b/packages/mobile/src/page/Home/SuggestionModal/index.tsx
@@ -81,7 +81,7 @@ function SuggestionModal({ currentTemperature, onClick }: Props) {
           aria-label="옷차림 추천 닫기"
           onClick={onClick}
         >
-          <Close size={14} stroke="#828282" />
+          <Close size={14} stroke="#5E5E5E" />
         </button>
         <ul className={$["temperature-list"]}>
           {TEMPERATURE_LIST.map(({ minTemp, maxTemp, displayTemp }) => {

--- a/packages/mobile/src/page/Home/SuggestionModal/style.module.scss
+++ b/packages/mobile/src/page/Home/SuggestionModal/style.module.scss
@@ -35,7 +35,7 @@
       }
 
       .current-temperature {
-        color: $black-100;
+        color: $black-80;
       }
     }
 
@@ -64,7 +64,7 @@
       }
 
       .current-suggestion {
-        color: $black-100;
+        color: $black-80;
       }
     }
   }


### PR DESCRIPTION
## 👀 이슈

**크기가 작은 PR로, 셀프 어프루브 후 머지하겠습니다~**
resolve #796

## 👩‍💻 작업 사항
- [x] 홈 식단 카드 수정 버튼, 시간, 메뉴가 없을 때 표시하는 안내문 색깔 변경.
- [x] 홈 옷차림 추천 모달 닫기 버튼 색깔 변경. 
- [x] (접근성 수정에 포함되는 건 아니지만) 옷차림 추천 모달에서 잘못 마크업한 색상 변경. 
<!-- 작업한 내용을 적어주세요. -->

## ✅ 참고 사항
이슈에 첨부한 디자인 가이드 참고해주시면 감사하겠습니다~
<!-- 공유할 내용, 스크린샷 등을 넣어 주세요. -->
