### PR TITLE
[mobile] 일정 페이지에서 즐겨찾기 탭이 비어있을 때 표시되는 일러스트가 끝까지 스크롤되지 않는 문제 수정

### DIFF
--- a/packages/mobile/src/page/Calendar/CardBox/index.tsx
+++ b/packages/mobile/src/page/Calendar/CardBox/index.tsx
@@ -34,6 +34,7 @@ function CardBox({
           <span className={$.description}>오늘은 일정이 없어요</span>
         ) : (
           <img
+            className={$.image}
             width={239}
             src={guideEmptyFavoritesSchedule}
             alt="즐겨찾기된 학사일정 없음"

--- a/packages/mobile/src/page/Calendar/CardBox/style.module.scss
+++ b/packages/mobile/src/page/Calendar/CardBox/style.module.scss
@@ -1,19 +1,20 @@
-$top-height: 446px;
-$footer-height: 64px;
+$height-of-calendar-and-radio: 453px;
 
 .empty-box {
+  @include safe-area-100vh(min-height, calc($footer + $height-of-calendar-and-radio));
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  min-height: 161px;
-  @include safe-area-100vh(height, $top-height + $footer-height);
-  margin-top: 20px;
 
   .description {
     @include typography(14);
     color: $background-50;
     line-height: 30px;
+  }
+
+  .image {
+    margin: 20px 0 calc($footer + 20px);
   }
 }
 


### PR DESCRIPTION
## 👀 이슈

resolve #806

## 👩‍💻 작업 사항

- [x] 학사일정 탭이 비어있을 때 일정이 없음을 알리는 문구가 모든 화면 사이즈에서 중앙정렬될 수 있도록 수정.
- [x] 즐겨찾기 탭이 비어있을 때 표시되는 일러스트가 모든 화면 사이즈에서 끝까지 스크롤될 수 있도록 수정.
<!-- 작업한 내용을 적어주세요. -->

## ✅ 참고 사항

- iPhoneSE1 화면 사이즈에서 테스트했습니다.

<img width="372" alt="스크린샷 2023-04-05 오전 12 04 13" src="https://user-images.githubusercontent.com/71015915/229836906-08fe75b7-5184-4ad9-bd17-58553ff6a7f6.png">
<img width="373" alt="스크린샷 2023-04-05 오전 12 04 20" src="https://user-images.githubusercontent.com/71015915/229836917-c29b12f9-cf6f-4aa9-8907-4803e25ffae8.png">

<!-- 공유할 내용, 스크린샷 등을 넣어 주세요. -->
