### PR TITLE
[mobile] 홈 옷차림 추천 모달에서 누락된 온도 구간 추가

### DIFF
--- a/packages/mobile/src/page/Home/SuggestionModal/index.tsx
+++ b/packages/mobile/src/page/Home/SuggestionModal/index.tsx
@@ -34,6 +34,12 @@ const TEMPERATURE_LIST = [
     suggestionList: "얇은 니트, 맨투맨, 가디건, 청바지",
   },
   {
+    minTemp: 12,
+    maxTemp: 16,
+    displayTemp: "12~16°C",
+    suggestionList: "후드티, 바람막이, 슬랙스",
+  },
+  {
     minTemp: 9,
     maxTemp: 11,
     displayTemp: "9~11°C",


### PR DESCRIPTION
## 👀 이슈

**작업 크기가 크지 않아 셀프 어프루브 하겠습니다~**

resolve #809

## 👩‍💻 작업 사항

- [x] 12 ~ 16도에 해당하는 온도와 옷차림 설명 데이터를 추가.
<!-- 작업한 내용을 적어주세요. -->

## ✅ 참고 사항
<img width="383" alt="스크린샷 2023-04-05 오후 9 21 17" src="https://user-images.githubusercontent.com/71015915/230078946-e10b028f-7f0b-4586-b591-9d3d8fec1c7b.png">

<!-- 공유할 내용, 스크린샷 등을 넣어 주세요. -->
