### PR TITLE
[mobile] 일정 캘린더에서 일정 있음을 표시하는 점을 날짜 텍스트에 더 가까이 붙이기

### DIFF
--- a/packages/mobile/src/page/Calendar/Date/style.module.scss
+++ b/packages/mobile/src/page/Calendar/Date/style.module.scss
@@ -38,7 +38,7 @@
     .schedule-dot {
         width: 5px;
         height: 5px;
-        margin-top: 7px;
+        margin-top: 4px;
         border-radius: calc(5px / 2);
         background-color: $black-20;
     }


### PR DESCRIPTION
## 👀 이슈

resolve #808

## 👩‍💻 작업 사항

- [x] 일정을 표시하는 점과 날짜 텍스트 사이의 마진 줄이기.
<!-- 작업한 내용을 적어주세요. -->

## ✅ 참고 사항
### 수정전
<img width="106" alt="image" src="https://user-images.githubusercontent.com/71015915/230095618-8bb9bf93-f98d-4155-84b6-1af3e4f504eb.png">

### 수정후
<img width="86" alt="image" src="https://user-images.githubusercontent.com/71015915/230095289-8b6c09e4-e5db-4790-b009-3235d8b9a120.png">


<!-- 공유할 내용, 스크린샷 등을 넣어 주세요. -->
