### PR TITLE
[mobile] fullModalTemplate header z-index 제거

### DIFF
--- a/packages/mobile/src/components/templates/FullPageModalTemplate/style.module.scss
+++ b/packages/mobile/src/components/templates/FullPageModalTemplate/style.module.scss
@@ -12,7 +12,6 @@
     height: 60px;
     padding: 0 24px;
     background: #fff;
-    z-index: 100;
 
     .left {
       display: flex;


### PR DESCRIPTION
## 👀 이슈
- ios에서 홈 > 설정 > 문의하기 헤더 가려지지 않는 현상 발생

## 👩‍💻 작업 사항
- header의 z-index 제거

## ✅ 참고 사항

