### PR TITLE
[server] 토큰 한번에 1000개씩 보내기

### DIFF
--- a/packages/server/src/fcm/fcm.service.ts
+++ b/packages/server/src/fcm/fcm.service.ts
@@ -90,17 +90,6 @@ export class FcmService {
         url: `https://dev-mobile.cmiteam.kr/article/detail/${article.id}`,
       });
     }
-
-    // subscribers.forEach((user) => {
-    //   const notification = { title: boardTitle, body: article.title };
-    //   const { fcmToken } = user;
-
-    //   if (fcmToken)
-    //     this.sendNotice(fcmToken, notification, {
-    //       articleId: article.id.toString(),
-    //       url: `https://dev-mobile.cmiteam.kr/article/detail/${article.id}`,
-    //     });
-    // });
   }
 
   async sendNotice(

--- a/packages/server/src/fcm/fcm.service.ts
+++ b/packages/server/src/fcm/fcm.service.ts
@@ -30,7 +30,7 @@ export class FcmService {
   }
 
   private static message(
-    to: string,
+    to: string | string[],
     notification: { title: string; body: string },
     data?: object,
   ) {
@@ -40,8 +40,16 @@ export class FcmService {
       throw new BadRequestException("Is empty!");
     }
 
+    if (typeof to === "string") {
+      return {
+        to,
+        notification,
+        data,
+      };
+    }
+
     return {
-      to,
+      registration_ids: to,
       notification,
       data,
     };
@@ -65,20 +73,39 @@ export class FcmService {
       ? `${board.parent.name} > ${board.name}`
       : board.name;
 
-    subscribers.forEach((user) => {
-      const notification = { title: boardTitle, body: article.title };
-      const { fcmToken } = user;
+    const notification = { title: boardTitle, body: article.title };
+    const tokens = subscribers
+      .map((subscriber) => subscriber.fcmToken)
+      .filter((value): value is string => {
+        return typeof value === "string";
+      });
 
-      if (fcmToken)
-        this.sendNotice(fcmToken, notification, {
-          articleId: article.id.toString(),
-          url: `https://dev-mobile.cmiteam.kr/article/detail/${article.id}`,
-        });
-    });
+    const chunkSize = 1000;
+
+    for (let i = 0; i < tokens.length; i += chunkSize) {
+      const chunkTokens = tokens.slice(i, i + chunkSize);
+
+      this.sendNotice(chunkTokens, notification, {
+        articleId: article.id.toString(),
+        url: `https://dev-mobile.cmiteam.kr/article/detail/${article.id}`,
+      });
+    }
+
+    // subscribers.forEach((user) => {
+    //   const notification = { title: boardTitle, body: article.title };
+    //   const { fcmToken } = user;
+
+    //   if (fcmToken)
+    //     this.sendNotice(fcmToken, notification, {
+    //       articleId: article.id.toString(),
+    //       url: `https://dev-mobile.cmiteam.kr/article/detail/${article.id}`,
+    //     });
+    // });
   }
 
   async sendNotice(
-    to: string,
+    // FCM에서는 단일 요청으로 최대 2000개의 등록 토큰에게 알림을 보낼 수 있습니다
+    to: string | string[],
     notification: { title: string; body: string },
     data: object,
   ): Promise<void> {
@@ -86,10 +113,12 @@ export class FcmService {
       FcmService.message(to, notification, data),
       async (err, res) => {
         if (err) {
-          const { error } = JSON.parse(err).results[0];
+          if (typeof to === "string") {
+            const { error } = JSON.parse(err).results[0];
 
-          if ([ "InvalidRegistration", "NotRegistered" ].includes(error)) {
-            await this.userService.deleteByFcmToken(to);
+            if ([ "InvalidRegistration", "NotRegistered" ].includes(error)) {
+              await this.userService.deleteByFcmToken(to);
+            }
           }
 
           console.error("[sendNotice] ", { err });

--- a/packages/server/src/fcm/fcm.spec.ts
+++ b/packages/server/src/fcm/fcm.spec.ts
@@ -5,12 +5,12 @@ import { FcmService } from "./fcm.service";
 
 describe("FCM module", () => {
   let fcmService: FcmService;
-  const data = { title: "CMI", body: "공지사항 등록" };
-  const 제스 =
-    "fH3Qkxyj-UnQr2PFa-xHL0:APA91bFS9BAXPqPSM5RLt-QmsEbYFsTPbHDsRFeQcCRYqAzpbet3BD298gLxDgkPMs0S7CTiGqLLkTpiSTnY8cBgl5pXeoRfRuH3VZkMHAwfhGehOFtZ3kO5e-YIu1gB8b8cNITzYCQI";
+  const data = { title: "CMI", body: "공지사항 알림 테스트" };
+  const IOS =
+    "cyZiY2-vLkjni_Qx7RBOLq:APA91bEmEYg6TZpvaXYLZ3cmzsxsQ9aZslqhf9Gki-EPo6APk48dmNp16KmzDN2JHmm9Gy_GEjbk4ZSSWwltRisOnobSEVBuPBM-MN1WnHhhLpVe8wKIsj3zUSdsgi-pGmeZJWWI5jvc";
 
-  const 브루니 =
-    "d_2nPsxlDkYMottYFPHjOY:APA91bHpaRkD6lmcc1CFLRY1Gb0mBQVMVd6RoQw0OwPNVmUBa_hqRuaWT-j3V5VxSPUFpB3-sVaI6bdEeMaNLeLEUzzlqEhirE-fN1na6F_Mr0w0EOOQ11B5JUAMRRLovbMN0IqZ48Zm";
+  const ANDORIOD =
+    "fsbiefTlSSmSSUArzfyPK9:APA91bGG14rAlFJGLjJoa6JW03ziDK3Er01j9hfMmSj98O7M3LpH17G2ArIw9K91YPoUZsIGd8Ec86R2XDHkpx_LqJWbjNatrutJkYEu2KI5LdJHF6wcGCtNU625FWTz43Ea__YPVwH_";
 
   beforeAll(async () => {
     const module = await Test.createTestingModule({
@@ -21,10 +21,14 @@ describe("FCM module", () => {
   });
 
   test("send message ios", async () => {
-    await fcmService.sendNotice(제스, data, {});
+    await fcmService.sendNotice(IOS, data, {});
   });
 
   test("send message aos", async () => {
-    await fcmService.sendNotice(브루니, data, {});
+    await fcmService.sendNotice(ANDORIOD, data, {});
+  });
+
+  test("send message multiple", async () => {
+    await fcmService.sendNotice([ ANDORIOD, IOS, "4444" ], data, {});
   });
 });


### PR DESCRIPTION
## 👀 이슈

FCM 메시지를 유저별로 하나씩 보내서 네트워크 트래픽 비용낭비

## 👩‍💻 작업 사항

#### AS-IS
FCM 메시지를 유저별로 하나씩 보냄

#### TO-BE
배열을 사용해서 FCM 메시지를 한번에 1000명의 유저에게 동시에 보냄 (2000명까지 가능)

## ✅ 참고 사항

테스트 완료
