### PR TITLE
[mobile] 캠퍼스맵 페이지에 새로고침 버튼 추가

### DIFF
--- a/packages/mobile/src/components/shared/ReloadButton/index.tsx
+++ b/packages/mobile/src/components/shared/ReloadButton/index.tsx
@@ -7,9 +7,15 @@ import $ from "./style.module.scss";
 export type ReloadButtonProps = {
   buttonType: "text" | "icon";
   onClick: () => void;
+  stroke?: string;
 } & DefaultProps;
 
-function ReloadButton({ className, buttonType, onClick }: ReloadButtonProps) {
+function ReloadButton({
+  className,
+  buttonType,
+  onClick,
+  stroke = "#9FB0C6",
+}: ReloadButtonProps) {
   if (buttonType === "text")
     return (
       <button
@@ -17,7 +23,7 @@ function ReloadButton({ className, buttonType, onClick }: ReloadButtonProps) {
         onClick={onClick}
         className={classNames($["reload-button-with-text"], className)}
       >
-        <Reload stroke="#9FB0C6" size={12.5} />
+        <Reload stroke={stroke} size={12.5} />
         <span className={$["reload-text"]}>새로고침</span>
       </button>
     );
@@ -28,7 +34,7 @@ function ReloadButton({ className, buttonType, onClick }: ReloadButtonProps) {
       onClick={onClick}
       className={classNames($["reload-button"], className)}
     >
-      <Reload stroke="#9FB0C6" size={20} />
+      <Reload stroke={stroke} size={20} />
     </button>
   );
 }

--- a/packages/mobile/src/hooks/api/school/index.ts
+++ b/packages/mobile/src/hooks/api/school/index.ts
@@ -6,17 +6,25 @@ import { GetParams } from "src/type/utils";
 export const useSchoolsQuery = (
   params?: GetParams<typeof PlaceApiService.placeControllerFindSchool>,
 ) => {
-  return useCoreQuery(queryKey.schools({ ...params }), () => {
-    return PlaceApiService.placeControllerFindSchool({
-      ...params,
-    });
-  }, {suspense: true});
+  return useCoreQuery(
+    queryKey.schools({ ...params }),
+    () => {
+      return PlaceApiService.placeControllerFindSchool({
+        ...params,
+      });
+    },
+    { suspense: true },
+  );
 };
 
 export const useSchoolQuery = (
   params: GetParams<typeof PlaceApiService.placeControllerFindOneSchool>,
 ) => {
-  return useCoreQuery(queryKey.school(params), () => {
-    return PlaceApiService.placeControllerFindOneSchool({ ...params });
-  }, {suspense: true});
+  return useCoreQuery(
+    queryKey.school(params),
+    () => {
+      return PlaceApiService.placeControllerFindOneSchool({ ...params });
+    },
+    { suspense: true },
+  );
 };

--- a/packages/mobile/src/hooks/api/school/index.ts
+++ b/packages/mobile/src/hooks/api/school/index.ts
@@ -9,11 +9,15 @@ export const useSchoolsQuery = (
     | Omit<CustomQueryOptions<PlaceSchoolDto[], null>, "queryKey" | "queryFn">
     | undefined,
 ) => {
-  return useCoreQuery(queryKey.schools({ ...params }), () => {
-    return PlaceApiService.placeControllerFindSchool({
-      ...params,
-    });
-  }, options);
+  return useCoreQuery(
+    queryKey.schools({ ...params }),
+    () => {
+      return PlaceApiService.placeControllerFindSchool({
+        ...params,
+      });
+    },
+    options,
+  );
 };
 
 export const useSchoolQuery = (

--- a/packages/mobile/src/hooks/api/school/index.ts
+++ b/packages/mobile/src/hooks/api/school/index.ts
@@ -1,30 +1,25 @@
-import { useCoreQuery } from "@hooks/api/core";
-import { PlaceApiService } from "@shared/swagger-api/generated";
+import { CustomQueryOptions, useCoreQuery } from "@hooks/api/core";
+import { PlaceApiService, PlaceSchoolDto } from "@shared/swagger-api/generated";
 import { queryKey } from "src/consts/react-query/queryKey";
 import { GetParams } from "src/type/utils";
 
 export const useSchoolsQuery = (
   params?: GetParams<typeof PlaceApiService.placeControllerFindSchool>,
+  options?:
+    | Omit<CustomQueryOptions<PlaceSchoolDto[], null>, "queryKey" | "queryFn">
+    | undefined,
 ) => {
-  return useCoreQuery(
-    queryKey.schools({ ...params }),
-    () => {
-      return PlaceApiService.placeControllerFindSchool({
-        ...params,
-      });
-    },
-    { suspense: true },
-  );
+  return useCoreQuery(queryKey.schools({ ...params }), () => {
+    return PlaceApiService.placeControllerFindSchool({
+      ...params,
+    });
+  }, options);
 };
 
 export const useSchoolQuery = (
   params: GetParams<typeof PlaceApiService.placeControllerFindOneSchool>,
 ) => {
-  return useCoreQuery(
-    queryKey.school(params),
-    () => {
-      return PlaceApiService.placeControllerFindOneSchool({ ...params });
-    },
-    { suspense: true },
-  );
+  return useCoreQuery(queryKey.school(params), () => {
+    return PlaceApiService.placeControllerFindOneSchool({ ...params });
+  });
 };

--- a/packages/mobile/src/hooks/api/school/index.ts
+++ b/packages/mobile/src/hooks/api/school/index.ts
@@ -10,7 +10,7 @@ export const useSchoolsQuery = (
     return PlaceApiService.placeControllerFindSchool({
       ...params,
     });
-  });
+  }, {suspense: true});
 };
 
 export const useSchoolQuery = (
@@ -18,5 +18,5 @@ export const useSchoolQuery = (
 ) => {
   return useCoreQuery(queryKey.school(params), () => {
     return PlaceApiService.placeControllerFindOneSchool({ ...params });
-  });
+  }, {suspense: true});
 };

--- a/packages/mobile/src/page/Place/Detail/PlaceDetailBody.tsx
+++ b/packages/mobile/src/page/Place/Detail/PlaceDetailBody.tsx
@@ -2,24 +2,14 @@ import { PlaceSchoolDto } from "@shared/swagger-api/generated";
 import { useSchoolsQuery } from "src/hooks/api/school";
 import DetailGroup from "src/page/Place/DetailGroup";
 
+import getUpperCasePosition from "./getUpperCasePosition";
+
 type Props = { position: string };
 
-type GetUpperCasePosition = (
-  position: string,
-) => PlaceSchoolDto["school"]["area"];
-
-export const getUpperCasePosition: GetUpperCasePosition = (position) => {
-  const area = position === "all" ? undefined : position.split("")[0].toUpperCase();
-  return area as PlaceSchoolDto["school"]["area"];
-};
-
 function PlaceDetailBody({ position }: Props) {
-  const currentPosition =
-    position === "all" ? undefined : position.split("")[0].toUpperCase();
+  const currentPosition = getUpperCasePosition(position);
 
-  const { data: schoolsData } = useSchoolsQuery({
-    area: currentPosition as PlaceSchoolDto["school"]["area"],
-  });
+  const { data: schoolsData } = useSchoolsQuery({ area: currentPosition });
 
   if (!schoolsData) return null;
 

--- a/packages/mobile/src/page/Place/Detail/PlaceDetailBody.tsx
+++ b/packages/mobile/src/page/Place/Detail/PlaceDetailBody.tsx
@@ -4,6 +4,15 @@ import DetailGroup from "src/page/Place/DetailGroup";
 
 type Props = { position: string };
 
+type GetUpperCasePosition = (
+  position: string,
+) => PlaceSchoolDto["school"]["area"];
+
+export const getUpperCasePosition: GetUpperCasePosition = (position) => {
+  const area = position === "all" ? undefined : position.split("")[0].toUpperCase();
+  return area as PlaceSchoolDto["school"]["area"];
+};
+
 function PlaceDetailBody({ position }: Props) {
   const currentPosition =
     position === "all" ? undefined : position.split("")[0].toUpperCase();

--- a/packages/mobile/src/page/Place/Detail/PlaceDetailBody.tsx
+++ b/packages/mobile/src/page/Place/Detail/PlaceDetailBody.tsx
@@ -9,7 +9,10 @@ type Props = { position: string };
 function PlaceDetailBody({ position }: Props) {
   const currentPosition = getUpperCasePosition(position);
 
-  const { data: schoolsData } = useSchoolsQuery({ area: currentPosition });
+  const { data: schoolsData } = useSchoolsQuery(
+    { area: currentPosition },
+    { suspense: true },
+  );
 
   if (!schoolsData) return null;
 

--- a/packages/mobile/src/page/Place/Detail/getUpperCasePosition.ts
+++ b/packages/mobile/src/page/Place/Detail/getUpperCasePosition.ts
@@ -1,0 +1,12 @@
+import { PlaceSchoolDto } from "@shared/swagger-api/generated";
+
+type GetUpperCasePosition = (
+  position: string,
+) => PlaceSchoolDto["school"]["area"];
+
+const getUpperCasePosition: GetUpperCasePosition = (position) => {
+  const area = position === "all" ? undefined : position.split("")[0].toUpperCase();
+  return area as PlaceSchoolDto["school"]["area"];
+};
+
+export default getUpperCasePosition;

--- a/packages/mobile/src/page/Place/Detail/getUpperCasePosition.ts
+++ b/packages/mobile/src/page/Place/Detail/getUpperCasePosition.ts
@@ -5,7 +5,8 @@ type GetUpperCasePosition = (
 ) => PlaceSchoolDto["school"]["area"];
 
 const getUpperCasePosition: GetUpperCasePosition = (position) => {
-  const area = position === "all" ? undefined : position.split("")[0].toUpperCase();
+  const area =
+    position === "all" ? undefined : position.split("")[0].toUpperCase();
   return area as PlaceSchoolDto["school"]["area"];
 };
 

--- a/packages/mobile/src/page/Place/Detail/index.tsx
+++ b/packages/mobile/src/page/Place/Detail/index.tsx
@@ -3,6 +3,7 @@ import ChipGroup from "@components/molecules/ChipGroup";
 import FullPageModalTemplate from "@components/templates/FullPageModalTemplate";
 import ErrorFallback from "src/components/atoms/ErrorFallback";
 import SuspenseFallback from "src/components/atoms/SuspenseFallback";
+import ReloadButton from "src/components/shared/ReloadButton";
 import AsyncBoundary from "src/components/templates/AsyncBoundary";
 import useSearch from "src/hooks/useSearch";
 import PlaceDetailBody from "src/page/Place/Detail/PlaceDetailBody";
@@ -10,6 +11,7 @@ import { useAppDispatch } from "src/store";
 import { setHashMenu } from "src/store/placeSlice";
 
 import { menuList } from "../../../__mocks__/index";
+import reloadPlaceQueries from "./reloadPlaceQueries";
 
 function PlaceDetail() {
   const dispatch = useAppDispatch();
@@ -35,10 +37,15 @@ function PlaceDetail() {
     dispatch(setHashMenu({ hashString: position }));
   };
 
+  const handleReloadClick = () => {
+    return reloadPlaceQueries(position);
+  };
+
   return (
     <FullPageModalTemplate
       left={<LeftArrow stroke="#5e5e5e" size={16} />}
       title="캠퍼스맵"
+      right={<ReloadButton buttonType="icon" onClick={handleReloadClick} stroke="#5E5E5E" />}
     >
       <ChipGroup
         list={menuList}

--- a/packages/mobile/src/page/Place/Detail/reloadPlaceQueries.ts
+++ b/packages/mobile/src/page/Place/Detail/reloadPlaceQueries.ts
@@ -1,7 +1,7 @@
 import { queryKey } from "src/consts/react-query/queryKey";
 import { queryClient } from "src/main";
 
-import { getUpperCasePosition } from "./PlaceDetailBody";
+import getUpperCasePosition from "./getUpperCasePosition";
 
 function reloadPlaceQueries(position: string) {
   const area = getUpperCasePosition(position);

--- a/packages/mobile/src/page/Place/Detail/reloadPlaceQueries.ts
+++ b/packages/mobile/src/page/Place/Detail/reloadPlaceQueries.ts
@@ -1,0 +1,11 @@
+import { queryKey } from "src/consts/react-query/queryKey";
+import { queryClient } from "src/main";
+
+import { getUpperCasePosition } from "./PlaceDetailBody";
+
+function reloadPlaceQueries(position: string) {
+  const area = getUpperCasePosition(position);
+  queryClient.resetQueries(queryKey.schools({ area }));
+}
+
+export default reloadPlaceQueries;


### PR DESCRIPTION
## 👀 이슈

resolve #871

## 👩‍💻 작업 사항

- [x] 캠퍼스맵 헤더에 새로고침 버튼 추가.
- [x] 새로고침 버튼 컴포넌트가 `stroke` 프롭을 받아서 색상을 바꿀 수 있도록 수정(기존 색상은 기본값으로 넣었습니다.). 
- [x] 캠퍼스맵 새로고침 동작을 `reloadPlaceQueries` 함수로 구현.
- [x] `north`, `south` 등의 문자열을 `N`, `S` 등으로 변환하는 로직을 함수로 분리.
- [x] `useSchoolQuery` 훅에서 `useCoreQuery` 옵션으로 `{suspense: true}` 추가(누락되어 있어 Fallback 컴포넌트가 나타나지 않고 있었습니다.). 
<!-- 작업한 내용을 적어주세요. -->

## ✅ 참고 사항

https://user-images.githubusercontent.com/71015915/230768494-e3a97179-3e2c-47cc-aea0-f75c10e45049.mov


https://user-images.githubusercontent.com/71015915/230768530-1aa1ffde-71ec-4708-9926-08a17242241b.mov


<!-- 공유할 내용, 스크린샷 등을 넣어 주세요. -->
