### PR TITLE
[mobile] 이미지 프리뷰 크기 제한, 데스크탑환경에서는 모달 안띄우게 수정

### DIFF
--- a/packages/mobile/src/components/molecules/SwiperImage/style.module.scss
+++ b/packages/mobile/src/components/molecules/SwiperImage/style.module.scss
@@ -26,6 +26,7 @@
       .image {
         min-width: 100%;
         height: auto;
+        max-height: 80vh;
         object-fit: contain;
       }
   }
@@ -36,6 +37,7 @@
     display: flex;
     justify-content: space-between;
     width: 100%;
+    padding: 0 40px;
 
     button:disabled {
       visibility: hidden;

--- a/packages/mobile/src/components/shared/ImageModal/index.tsx
+++ b/packages/mobile/src/components/shared/ImageModal/index.tsx
@@ -15,7 +15,6 @@ type Props = {
 } & DefaultProps;
 
 function ImageModal({ order, setOrder, onClose, images }: Props) {
-  // TODO: 백엔드 수정 후 확인필요
   const handleDownloadClick = async () => {
     const { id, url } = images[order - 1];
 

--- a/packages/mobile/src/components/shared/ImageModal/style.module.scss
+++ b/packages/mobile/src/components/shared/ImageModal/style.module.scss
@@ -20,7 +20,7 @@
     height: calc(var(--vh, 1vh) * 100);
 
     .modal-slider {
-      top: 40%;
+      top:45%;
       margin: auto;
       transform: translateY(-50%);
     }

--- a/packages/mobile/src/page/Article/Detail/index.tsx
+++ b/packages/mobile/src/page/Article/Detail/index.tsx
@@ -15,6 +15,7 @@ import classnames from "classnames";
 import dayjs from "dayjs";
 import { EMPTY_TITLE_GUIDE_MESSAGE } from "src/consts";
 import ArticleFooter from "src/page/Article/components/Footer";
+import { isDevOrWebview } from "src/utils/webview";
 
 import $ from "./style.module.scss";
 
@@ -45,6 +46,7 @@ function ArticleDetail() {
     images,
     url,
   } = articleData;
+
 
   const handleToggleLikeClick = (articleId: number) => {
     if (isLike) {
@@ -105,7 +107,7 @@ function ArticleDetail() {
         </div>
         <ArticleFooter {...{ articleId, isBookmark, url }} />
       </FullPageModalTemplate>
-      {isOpen && images?.length && (
+      {isOpen && images?.length && isDevOrWebview && (
         <ImageModal
           {...{ order, setOrder, images }}
           onClose={handleModalClose}

--- a/packages/mobile/src/page/Cafeteria/CafateriaBody/index.tsx
+++ b/packages/mobile/src/page/Cafeteria/CafateriaBody/index.tsx
@@ -9,6 +9,7 @@ import CafeteriaMenuCard from "src/components/molecules/CafeteriaMenuCard";
 import { cafeteriaQuery, useCafeteriaQuery } from "src/hooks/api/cafeteria";
 import { holidayQuery, useHoliday } from "src/hooks/api/schedule";
 import { queryClient } from "src/main";
+import { isDesktop } from "src/utils/webview";
 
 import { getCafeteriaTime } from "../constants";
 import reloadCafeteriaQueries from "./reloadCafeteriaQueries";
@@ -70,7 +71,11 @@ function CafeteriaBody({ fullDate, selectedMenu }: Props) {
             <ShareButton
               size={20}
               stroke="#9FB0C6"
-              successMsg="식단 링크가 클립보드에 복사되었습니다."
+              successMsg={
+                isDesktop
+                  ? "식단 링크가 복사되었습니다."
+                  : "식단 링크가 클립보드에 복사되었습니다."
+              }
               className={$["share-button"]}
             />
             <ReloadButtonForCafeteria buttonType="icon" />


### PR DESCRIPTION
## 👀 이슈

resolve #844 resolve #863

## 👩‍💻 작업 사항
이미지 높이가 길 경우 위 사진처럼 되는 경우가 있어서 프리뷰 크기 제한
데스크탑환경에서는 모달 안띄우게 수정
모바일환경에서는 화살표 안보이게 수정
토스트메시지 수정

<!-- 작업한 내용을 적어주세요. -->
<img width="412" alt="image" src="https://user-images.githubusercontent.com/38103082/230899321-383adeb6-df70-421f-9f18-a30686929675.png">

## ✅ 참고 사항

<!-- 공유할 내용, 스크린샷 등을 넣어 주세요. -->
