### PR TITLE
[admin] 게시물 목록 메뉴를 두번 클릭시 게시물 목록이 나타나지 않는 버그 수정

### DIFF
--- a/packages/admin/src/pages/ArticlePage/ArticleWrite/SelectBoard/SelectBoard.tsx
+++ b/packages/admin/src/pages/ArticlePage/ArticleWrite/SelectBoard/SelectBoard.tsx
@@ -17,12 +17,20 @@ export default function SelectBoard({ boardId, onSelectBoard }: Props) {
   const { data: authorityBoards, isLoading } = useQuery(
     [ "boardAuthority" ],
     () => AdminApiService.adminControllerGetAuthorityBoards(),
-    {
-      onSuccess: (boards) => {
-        setSelectedBoardId(boardId ?? boards[0].id);
-      },
-    },
   );
+
+  useEffect(() => {
+    if (authorityBoards) {
+      if (boardId) {
+        setSelectedBoardId(boardId);
+        onSelectBoard?.(boardId);
+      } else {
+        const { id } = authorityBoards[0];
+        setSelectedBoardId(id);
+        onSelectBoard?.(id);
+      }
+    }
+  }, [ authorityBoards, boardId ]);
 
   useEffect(() => {
     if (selectedBoardId) {


### PR DESCRIPTION
## 👀 이슈

`게시물 목록` 메뉴를 두번 클릭시 게시물 목록이 나타나지 않는 버그 

## 👩‍💻 작업 사항

<!-- 작업한 내용을 적어주세요. -->

## ✅ 참고 사항

<!-- 공유할 내용, 스크린샷 등을 넣어 주세요. -->
