### PR TITLE
[scraper] 스크래퍼 캐시 무시

### DIFF
--- a/packages/scraper/src/scraper/scraper.ts
+++ b/packages/scraper/src/scraper/scraper.ts
@@ -66,12 +66,8 @@ const getScraper = async () => {
 
   const [ page ] = await browser.pages();
 
-  // 페이지 기본설정
-  await page.setViewport({
-    width: 1920,
-    height: 1080,
-    deviceScaleFactor: 1,
-  });
+  // DNS 캐시 무시를 위한 코드
+  page.setCacheEnabled(false);
 
   // 다이어로그 메시지 무시
   page.on("dialog", async (dialog) => {
@@ -90,6 +86,13 @@ const getScraper = async () => {
       } else {
         request.continue();
       }
+    });
+  } else {
+    // 페이지 기본설정
+    await page.setViewport({
+      width: 1920,
+      height: 1080,
+      deviceScaleFactor: 1,
     });
   }
 


### PR DESCRIPTION
## 👀 이슈

`Error: net::ERR_NAME_NOT_RESOLVED`로 페이지를 못불러오는 현상 
- curl 요청은 잘 응답함
- puppetter의 브라우저 DNS 캐시이슈?

## 👩‍💻 작업 사항

브라우저 캐시를 무시합니다

## ✅ 참고 사항

<!-- 공유할 내용, 스크린샷 등을 넣어 주세요. -->
