### PR TITLE
[scraper] SSL 관련 인증서 오류 무시

### DIFF
--- a/packages/scraper/src/scraper/scraper.ts
+++ b/packages/scraper/src/scraper/scraper.ts
@@ -61,7 +61,11 @@ const WINDOW_SIZE = {
 const getScraper = async () => {
   const browser = await puppeteer.launch({
     headless: configuration.headless,
-    args: [ `--window-size=${WINDOW_SIZE.WIDTH},${WINDOW_SIZE.HEIGHT}` ],
+    args: [
+      `--window-size=${WINDOW_SIZE.WIDTH},${WINDOW_SIZE.HEIGHT}`,
+      // SSL 관련 인증서 오류 무시
+      "--ignore-certificate-errors",
+    ],
   });
 
   const [ page ] = await browser.pages();


### PR DESCRIPTION
## 👀 이슈

스크래퍼에서 발생하는 하단 에러 해결
net::ERR_CERT_DATE_INVALID
net::ERR_CERT_COMMON_NAME_INVALID

## 👩‍💻 작업 사항

SSL 관련 인증서 오류 무시

## ✅ 참고 사항

<!-- 공유할 내용, 스크린샷 등을 넣어 주세요. -->
