### PR TITLE
[mobile] 홈 식당 정보 없을 때 있을 때 폰트 사이즈 다른 것 수정

### DIFF
--- a/packages/mobile/src/page/Home/Restaurant/EmptyCafeteria/index.tsx
+++ b/packages/mobile/src/page/Home/Restaurant/EmptyCafeteria/index.tsx
@@ -25,7 +25,6 @@ function EmptyCafeteria({ className, cafeteriaName, onClick }: Props) {
           <span className={$["cafeteria-name"]}>{cafeteriaName}</span>
           <Write stroke="#aaa" size={14} />
         </button>
-        <span className={$.time}></span>
       </div>
       <Line />
       <div className={$["food-box"]}>

--- a/packages/mobile/src/page/Home/Restaurant/Selected/index.tsx
+++ b/packages/mobile/src/page/Home/Restaurant/Selected/index.tsx
@@ -58,13 +58,13 @@ function Selected(props: Props) {
     <BorderBox height="auto" className={classNames($["menu-box"], className)}>
       <div className={$.header}>
         <div className={$["title-box"]}>
-          <span className={$.title}>{`${cafeteriaName} ${mealType}`}</span>
           <button
             type="button"
             className={$.button}
             aria-label="대표 식당 변경하기"
             onClick={onClick}
           >
+            <span className={$.title}>{`${cafeteriaName} ${mealType}`}</span>
             <Write stroke="#5E5E5E" size={14} />
           </button>
         </div>

--- a/packages/mobile/src/page/Home/Restaurant/Selected/style.module.scss
+++ b/packages/mobile/src/page/Home/Restaurant/Selected/style.module.scss
@@ -7,20 +7,26 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin-bottom: 17px;
+    margin-bottom: 7px;
     color: $black-100;
 
     .title-box {
+      .button {
+        line-height: 35px;
+      }
+
       .title {
-        @include typography(18);
+        @include typography(16);
+        margin-right: 10px;
         line-height: 25px;
         font-weight: 500;
         color: $black-100;
       }
 
-      .button {
-        padding: 10px;
+      .write {
+        display: inline-block;
         line-height: 1px;
+        vertical-align: top;
       }
     }
 


### PR DESCRIPTION
## 👀 이슈
- 홈 식당 정보 없을 때와 있을 때 폰트 사이즈가 달라서 수정했어요

## 👩‍💻 작업 사항
- 홈 식당 정보 없을 때와 있을 때 폰트 사이즈가 달라서 수정

## ✅ 참고 사항
[AS-IS]
<img width="402" alt="스크린샷 2023-06-25 오후 12 27 42" src="https://github.com/CMI-OSS/cbnu-alrami/assets/22065725/44cd6ac6-52da-4023-8b22-ab41812f06a9">

[TO-BE]
<img width="402" alt="스크린샷 2023-06-25 오후 12 28 24" src="https://github.com/CMI-OSS/cbnu-alrami/assets/22065725/56b683ba-8792-4682-a9f0-bdfe6b234699">
