### PR TITLE
[mobile] 학사일정 개선

### DIFF
--- a/packages/mobile/src/consts/react-query/queryKey.ts
+++ b/packages/mobile/src/consts/react-query/queryKey.ts
@@ -44,6 +44,7 @@ export const queryKey = {
   weathers: [ "weathers" ],
   schedules: [ "schedules" ],
   todaysSchedules: [ "todaysSchedules" ],
+  monthSchedules: [ "monthSchedules" ],
   holiday: [ "holiday" ],
   // Cafeteria 도메인
   cafeteria: (

--- a/packages/mobile/src/hooks/api/schedule/index.ts
+++ b/packages/mobile/src/hooks/api/schedule/index.ts
@@ -76,6 +76,40 @@ export const useTodaySchedulesQuery = (
   );
 };
 
+export const useMonthSchedulesQuery = (year: number, month: number) => {
+  const firstDayOfMonth = dayjs()
+    .year(year)
+    .month(month - 1)
+    .date(1);
+
+  const lastDayOfMonth = firstDayOfMonth.endOf("month");
+
+  return useCoreQuery<Schedule[], FormattedSchedule[]>(
+    [ ...queryKey.monthSchedules, year, month ],
+    () => {
+      return ScheduleApiService.scheduleControllerFindAll({
+        startDateTime: firstDayOfMonth.format("YYYY-MM-DD"),
+        endDateTime: lastDayOfMonth.format("YYYY-MM-DD"),
+      });
+    },
+    {
+      select: (data) => {
+        const schedules = data.map(
+          ({ startDateTime, endDateTime, ...last }) => {
+            return {
+              startDateTime: dayjs(startDateTime),
+              endDateTime: endDateTime ? dayjs(endDateTime) : null,
+              ...last,
+            };
+          },
+        );
+        return schedules;
+      },
+      suspense: true,
+    },
+  );
+};
+
 export const bookmarkScheduleQuery: CustomQueryOptions<
   Schedule[],
   FormattedSchedule[]

--- a/packages/mobile/src/page/Calendar/CalendarBody.tsx
+++ b/packages/mobile/src/page/Calendar/CalendarBody.tsx
@@ -36,8 +36,21 @@ export default function CalendarBody({ today, month, year }: Props) {
 
   if (!monthSchedules || !bookmarkSchedules) return null;
 
+  const filterdBookmarkSchedules =
+    bookmarkSchedules?.filter((schedule) => {
+      if (selectedDate.isSame(schedule.startDateTime, "month")) return true;
+      if (selectedDate.isBefore(schedule.startDateTime, "month")) return false;
+      if (
+        schedule.endDateTime &&
+        selectedDate.isAfter(schedule.endDateTime, "month")
+      )
+        return false;
+
+      return true;
+    }) ?? [];
+
   const schedules =
-    toggleSchedule === "all" ? monthSchedules : bookmarkSchedules;
+    toggleSchedule === "all" ? monthSchedules : filterdBookmarkSchedules;
   const calendarMap = getCalendarMap(year, month, schedules);
 
   const handleScheduleToggleChange: ChangeEventHandler<HTMLInputElement> = ({

--- a/packages/mobile/src/page/Calendar/CalendarBody.tsx
+++ b/packages/mobile/src/page/Calendar/CalendarBody.tsx
@@ -4,7 +4,6 @@ import dayjs from "dayjs";
 import {
   bookmarkScheduleQuery,
   useBookmarkSchedulesQuery,
-  useFullSchedulesQuery,
   useMonthSchedulesQuery,
 } from "src/hooks/api/schedule";
 import { queryClient } from "src/main";
@@ -25,20 +24,21 @@ type Props = {
 
 export default function CalendarBody({ today, month, year }: Props) {
   queryClient.prefetchQuery(bookmarkScheduleQuery);
-  const { data: allSchedules } = useFullSchedulesQuery(year);
+
   const { data: bookmarkSchedules } = useBookmarkSchedulesQuery();
   const [ toggleSchedule, setToggleSchedule ] = useState<ScheduleType>("all");
   const [ selectedDate, setSelectedDate ] = useSelectedDate(today, year, month);
-
-  if (!allSchedules || !bookmarkSchedules) return null;
-
-  const schedules = toggleSchedule === "all" ? allSchedules : bookmarkSchedules;
-  const calendarMap = getCalendarMap(year, month, schedules);
 
   const { data: monthSchedules } = useMonthSchedulesQuery(
     selectedDate.year(),
     selectedDate.month() + 1,
   );
+
+  if (!monthSchedules || !bookmarkSchedules) return null;
+
+  const schedules =
+    toggleSchedule === "all" ? monthSchedules : bookmarkSchedules;
+  const calendarMap = getCalendarMap(year, month, schedules);
 
   const handleScheduleToggleChange: ChangeEventHandler<HTMLInputElement> = ({
     target: { value },
@@ -61,7 +61,7 @@ export default function CalendarBody({ today, month, year }: Props) {
         {...{
           year,
           selectedDate,
-          schedules: monthSchedules ?? [],
+          schedules: schedules ?? [],
           bookmarkSchedules,
         }}
       />

--- a/packages/mobile/src/page/Calendar/CalendarBody.tsx
+++ b/packages/mobile/src/page/Calendar/CalendarBody.tsx
@@ -3,14 +3,14 @@ import { ChangeEventHandler, useState } from "react";
 import dayjs from "dayjs";
 import {
   bookmarkScheduleQuery,
-  fullScheduleQuery,
   useBookmarkSchedulesQuery,
   useFullSchedulesQuery,
+  useMonthSchedulesQuery,
 } from "src/hooks/api/schedule";
 import { queryClient } from "src/main";
 import RadioBox from "src/page/Calendar/RadioBox";
 import ScheduleCalendar from "src/page/Calendar/ScheduleCalendar";
-import { filterTodaySchedules, getCalendarMap } from "src/utils/calendarTools";
+import { getCalendarMap } from "src/utils/calendarTools";
 
 import CardBox from "./CardBox";
 import useSelectedDate from "./useSelectedDate";
@@ -24,7 +24,6 @@ type Props = {
 };
 
 export default function CalendarBody({ today, month, year }: Props) {
-  queryClient.prefetchQuery(fullScheduleQuery(year));
   queryClient.prefetchQuery(bookmarkScheduleQuery);
   const { data: allSchedules } = useFullSchedulesQuery(year);
   const { data: bookmarkSchedules } = useBookmarkSchedulesQuery();
@@ -35,7 +34,11 @@ export default function CalendarBody({ today, month, year }: Props) {
 
   const schedules = toggleSchedule === "all" ? allSchedules : bookmarkSchedules;
   const calendarMap = getCalendarMap(year, month, schedules);
-  const todaysSchedules = filterTodaySchedules(selectedDate, schedules);
+
+  const { data: monthSchedules } = useMonthSchedulesQuery(
+    selectedDate.year(),
+    selectedDate.month() + 1,
+  );
 
   const handleScheduleToggleChange: ChangeEventHandler<HTMLInputElement> = ({
     target: { value },
@@ -55,7 +58,12 @@ export default function CalendarBody({ today, month, year }: Props) {
       />
       <CardBox
         scheduleType={toggleSchedule}
-        {...{ year, selectedDate, todaysSchedules, bookmarkSchedules }}
+        {...{
+          year,
+          selectedDate,
+          schedules: monthSchedules ?? [],
+          bookmarkSchedules,
+        }}
       />
     </>
   );

--- a/packages/mobile/src/page/Calendar/CardBox/index.tsx
+++ b/packages/mobile/src/page/Calendar/CardBox/index.tsx
@@ -18,10 +18,10 @@ const CALENDAR_UNVISIBLE_POINT = 320;
 type Props = {
   bookmarkSchedules: FormattedSchedule[];
   scheduleType: ScheduleType;
-  todaysSchedules: FormattedSchedule[];
+  schedules: FormattedSchedule[];
 };
 
-function CardBox({ scheduleType, todaysSchedules, bookmarkSchedules }: Props) {
+function CardBox({ scheduleType, schedules, bookmarkSchedules }: Props) {
   const { y } = useScroll();
   const bookmarkedIDList = bookmarkSchedules.map(({ id }) => {
     return id;
@@ -39,12 +39,12 @@ function CardBox({ scheduleType, todaysSchedules, bookmarkSchedules }: Props) {
     );
   };
 
-  if (todaysSchedules.length === 0)
+  if (schedules.length === 0)
     return (
       <section className={$["empty-box"]}>
         {scheduleType === "all" ? (
           <>
-            <span className={$.description}>오늘은 일정이 없어요</span>
+            <span className={$.description}>이 달엔 일정이 없어요</span>
             <ReloadButtonForCalendar buttonType="text" />
           </>
         ) : (
@@ -63,7 +63,7 @@ function CardBox({ scheduleType, todaysSchedules, bookmarkSchedules }: Props) {
 
   return (
     <section className={$["card-box"]}>
-      {todaysSchedules.map(({ id, content, startDateTime, endDateTime }) => {
+      {schedules.map(({ id, content, startDateTime, endDateTime }) => {
         return (
           <CollegeCard
             key={id}

--- a/packages/mobile/src/page/Calendar/Date/index.tsx
+++ b/packages/mobile/src/page/Calendar/Date/index.tsx
@@ -1,5 +1,3 @@
-import { Dispatch } from "react";
-
 import classNames from "classnames";
 import { Dayjs } from "dayjs";
 import { StyleProps } from "src/type/props";
@@ -12,52 +10,30 @@ type Props = {
   today: Dayjs;
   index: number;
   month: number;
-  isSchedule: boolean;
   isHoliday: boolean;
-  selectedDate: Dayjs;
-  setSelectedDate: Dispatch<Dayjs>;
 } & StyleProps;
 
-function Date({
-  className,
-  date,
-  today,
-  index,
-  month,
-  isSchedule,
-  isHoliday,
-  selectedDate,
-  setSelectedDate,
-}: Props) {
+function Date({ className, date, today, index, month, isHoliday }: Props) {
   const { isSelected, isToday, isRed, isGray } = useDateState({
     today,
-    selectedDate,
     date,
     isHoliday,
     month,
     index,
   });
 
-  const handleSelect = () => {
-    setSelectedDate(date);
-  };
-
   return (
     <li className={classNames(className, $.container)}>
-      <button
-        type="button"
+      <div
         className={classNames($["date-button"], {
           [$["red-date"]]: isRed,
           [$["gray-date"]]: isGray,
           [$["selected-circle"]]: !isToday && isSelected,
           [$["today-circle"]]: isToday,
         })}
-        onClick={handleSelect}
-        aria-label={`${date.date()}일 선택하기`}
       >
         {date.date()}
-      </button>
-      {/* {isSchedule && <div className={$["schedule-dot"]} />} */}
+      </div>
     </li>
   );
 }

--- a/packages/mobile/src/page/Calendar/Date/index.tsx
+++ b/packages/mobile/src/page/Calendar/Date/index.tsx
@@ -57,7 +57,7 @@ function Date({
       >
         {date.date()}
       </button>
-      {isSchedule && <div className={$["schedule-dot"]} />}
+      {/* {isSchedule && <div className={$["schedule-dot"]} />} */}
     </li>
   );
 }

--- a/packages/mobile/src/page/Calendar/Date/useDateState.ts
+++ b/packages/mobile/src/page/Calendar/Date/useDateState.ts
@@ -5,21 +5,13 @@ import { DAY } from "src/utils/calendarTools";
 
 type Props = {
   today: Dayjs;
-  selectedDate: Dayjs;
   date: Dayjs;
   isHoliday: boolean;
   month: number;
   index: number;
 };
 
-function useDateState({
-  today,
-  selectedDate,
-  isHoliday,
-  date,
-  month,
-  index,
-}: Props) {
+function useDateState({ today, isHoliday, date, month, index }: Props) {
   const [ isSelected, setIsSelected ] = useState(false);
   const [ isToday, setIsToday ] = useState(false);
   const [ isRed, setIsRed ] = useState(false);
@@ -47,14 +39,6 @@ function useDateState({
     setIsRed(isSunday || isHoliday);
     setIsGray(currentMonth !== month);
   }, [ date, isSelected, month ]);
-
-  useEffect(() => {
-    if (selectedDate.isSame(date, "date")) {
-      setIsSelected(true);
-      return;
-    }
-    setIsSelected(false);
-  }, [ selectedDate ]);
 
   return { isSelected, isToday, isRed, isGray };
 }

--- a/packages/mobile/src/page/Calendar/ScheduleCalendar/index.tsx
+++ b/packages/mobile/src/page/Calendar/ScheduleCalendar/index.tsx
@@ -1,5 +1,3 @@
-import { Dispatch } from "react";
-
 import { Dayjs } from "dayjs";
 import { DateMap } from "src/page/Calendar";
 import Date from "src/page/Calendar/Date";
@@ -12,17 +10,10 @@ type Props = {
   calendarMap: DateMap[];
   today: Dayjs;
   selectedDate: Dayjs;
-  setSelectedDate: Dispatch<Dayjs>;
   month: number;
 };
 
-function ScheduleCalendar({
-  calendarMap,
-  today,
-  month,
-  selectedDate,
-  setSelectedDate,
-}: Props) {
+function ScheduleCalendar({ calendarMap, today, month, selectedDate }: Props) {
   return (
     <section className={$.box}>
       <ul className={$.calendar}>
@@ -36,7 +27,7 @@ function ScheduleCalendar({
                 key={date.format()}
                 className={$.date}
                 {...{ date, isSchedule, isHoliday, today }}
-                {...{ month, index, selectedDate, setSelectedDate }}
+                {...{ month, index }}
               />
             );
           },

--- a/packages/mobile/src/page/Home/ScheduleContainer/index.tsx
+++ b/packages/mobile/src/page/Home/ScheduleContainer/index.tsx
@@ -1,5 +1,5 @@
-import { Dayjs } from "dayjs";
-import { useTodaySchedulesQuery } from "src/hooks/api/schedule";
+import dayjs, { Dayjs } from "dayjs";
+import { useBookmarkSchedulesQuery } from "src/hooks/api/schedule";
 
 import Schedule from "../Schedule";
 import $ from "./style.module.scss";
@@ -9,17 +9,34 @@ type Props = {
 };
 
 export default function ScheduleContainer({ today }: Props) {
-  const { data } = useTodaySchedulesQuery(today.format("YYYY-MM-DD"));
+  const { data } = useBookmarkSchedulesQuery();
+
+  const schedules =
+    data?.filter((schedule) => {
+      const today = dayjs();
+
+      if (today.isSame(schedule.startDateTime, "date")) return true;
+      if (today.isBefore(schedule.startDateTime, "date")) return false;
+      if (schedule.endDateTime && today.isAfter(schedule.endDateTime, "date"))
+        return false;
+
+      return true;
+    }) ?? [];
 
   if (!data) return null;
 
   return (
     <div className={$.schedule}>
-      {data.schedules.map(({ id, content, startDateTime, endDateTime }) => {
+      {schedules.map(({ id, content, startDateTime, endDateTime }) => {
         return (
           <Schedule
             key={id}
-            {...{ content, startDateTime, endDateTime, today }}
+            {...{
+              content,
+              startDateTime: startDateTime.format("YYYY-MM-DD"),
+              endDateTime: endDateTime?.format("YYYY-MM-DD"),
+              today,
+            }}
           />
         );
       })}


### PR DESCRIPTION
## 👀 이슈

resolve #964 #963

## 👩‍💻 작업 사항

- [x] 학사일정: 오늘의 일정이 아닌 월 별 일정 제공 (예. 7월 페이지면 7월의 학사일정 전부를 제공)
- [x] 즐겨찾기: 월 별 학사일정 중 즐겨찾기 한 것만 띄움
- [x] 달력: 각 날짜를 선택하는 기능 삭제, 오늘 날짜 표시기능만 유지
- [x] 홈화면 일정: (1) 즐겨찾기 했으며, (2) 오늘 날짜에 해당되는 일정만 띄움


## ✅ 참고 사항

<!-- 공유할 내용, 스크린샷 등을 넣어 주세요. -->
