### PR TITLE
[mobile] 공지사항 컨텐츠 영역 이미지 사이즈 100% 자동 조절

### DIFF
--- a/packages/mobile/src/page/Article/Detail/style.module.scss
+++ b/packages/mobile/src/page/Article/Detail/style.module.scss
@@ -30,6 +30,11 @@
     .content {
       overflow-x: auto;
       overflow-y: hidden;
+
+      img {
+        width: 100% !important;
+        height: auto !important;
+      }
     }
 
     .heart {


### PR DESCRIPTION
## 👀 이슈

스크래퍼로 긁어온 게시물을 그대로 노출하다보니 이미지 사이즈가 pc 사이즈에 맞게된 컨텐츠들이 있음

<img width="380" alt="image" src="https://github.com/CMI-OSS/cbnu-alrami/assets/49256790/03e21af2-e404-4acb-9944-f830d5d168ac">

## 👩‍💻 작업 사항

- 모바일 화면 규격에 맞게 이미지의 폭은 100%를 유지하도록 수정

<img width="374" alt="image" src="https://github.com/CMI-OSS/cbnu-alrami/assets/49256790/da264c1d-ed6b-45ed-9365-d0a99fe21ddd">


## ✅ 참고 사항

<!-- 공유할 내용, 스크린샷 등을 넣어 주세요. -->
