### PR TITLE
[mobile] 아이콘 색상 수정

### DIFF
--- a/packages/mobile/src/components/shared/SubscriptionNoticeGroup/index.tsx
+++ b/packages/mobile/src/components/shared/SubscriptionNoticeGroup/index.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import Icon from "@components/atoms/icon/Icon";
 import classnames from "classnames";
 import { DefaultProps } from "src/type/props";
@@ -28,13 +26,13 @@ function SubscriptionNoticeGroup({
           <Icon
             name={isSubscribe ? "subscribe" : "unSubscribe"}
             size={24}
-            color={isSubscribe ? "#828282" : "#D66D6E"}
+            color={isSubscribe ? "#D66D6E" : "#828282"}
           />
 
           <Icon
             name={isNotice ? "alarm" : "unalarm"}
             size={24}
-            color={isNotice ? "#828282" : "#D66D6E"}
+            color={isNotice ? "#D66D6E" : "#828282"}
           />
         </div>
       </button>


### PR DESCRIPTION
## 👀 이슈
resolve #979 

## 👩‍💻 작업 사항
공지사항 - 미리보기 아이콘 색상이 반대로 되어 있어서 수정하였습니다. 

## ✅ 참고 사항
<img width="231" alt="스크린샷 2023-08-28 오후 7 58 51" src="https://github.com/CMI-OSS/cbnu-alrami/assets/22065725/652a8af1-8e2b-432f-88f1-d0d8ab6e9ff1">

<img width="238" alt="스크린샷 2023-08-28 오후 7 59 14" src="https://github.com/CMI-OSS/cbnu-alrami/assets/22065725/220b07c0-edda-47a5-b130-7e69001433c2">
